### PR TITLE
perf: single-pass PDF pipeline + live progress indicator

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -138,55 +138,53 @@ success = converter.convert_to_pdf(docx_path, pdf_path)
 
 The Word converter provides better formatting fidelity but requires Windows and installed Word. LibreOffice provides cross-platform compatibility with slightly different output formatting.
 
-### 6. PDF Content Analysis
+### 6. Single in-memory PDF edit session (Analysis → Overlay → Merge → Finalize)
 
-The `ContentAnalyzer` processes the base PDF:
+The base PDF (produced by Word/LibreOffice) is opened **once** and the same
+`fitz.Document` object is threaded through analysis, overlays, merges and marker
+removal, then saved a **single time**. This avoids reparsing/reserializing the
+document between stages and eliminates the previous `with_overlays` and `merged`
+intermediate PDF files (and one of the two full deflate/clean recompressions).
 
 ```python
-content_map, toc_pages = analyzer.analyze(pdf_path, placeholders, table_metadata)
+pdf_doc = fitz.open(base_pdf_path)                      # opened once
+content_map = analyzer.analyze(pdf_doc, placeholders, table_metadata)
+overlay_processor.process_overlays(pdf_doc, content_map)   # in place
+merge_processor.process_merges(pdf_doc, content_map)       # in place
+marker_remover.remove_markers(pdf_doc, markers, marker_pages)  # in place
+pdf_doc.save(output_path, garbage=4, deflate=True, clean=True)  # saved once
+overlay_processor.close_sources()                           # after save
 ```
 
-**Marker Detection:**
-- Searches for all marker text in the PDF using text extraction
-- Records exact position coordinates for each marker
-- Maps markers to their corresponding placeholder metadata
+**Marker Detection (`analyze`):**
+- A single sweep over the open document; each page is visited once and searched
+  only for markers not yet located, short-circuiting once all are found
+  (replacing the previous two opens + O(markers × pages) scan).
+- Records exact position coordinates for each marker and maps them to metadata.
 
 **Annotation Processing:**
-- Automatically detects and bakes PDF annotations into content
-- Ensures annotations are preserved during overlay operations
-- Uses `doc.bake()` for permanent annotation integration
+- Source/appendix annotations are baked once per document via `doc.bake()`.
 
-**TOC Detection:**
-- Identifies Table of Contents pages based on content patterns
-- Used for intelligent TOC merging in INSERT operations
+> Note: overlay source documents are kept open until *after* the final save,
+> because `show_pdf_page()` may reference them until the target is serialized.
+> `OverlayProcessor.close_sources()` releases them once the save completes.
 
-### 7. PDF Processing
+**Overlay Processing (Table-based):** `process_overlays(base_doc, content_map)`
+- Calculates overlay rectangles from marker position + table dimensions.
+- Applies content-aware cropping to source PDFs (unless `crop=false`).
+- Caches opened source docs, crop rects and page selections across a table's
+  per-page markers.
 
-**Overlay Processing (Table-based):**
-```python
-overlay_processor.process_overlays(base_pdf_path, content_map, output_path)
-```
+**Merge Processing (Paragraph-based):** `process_merges(output_doc, content_map)`
+- Inserts appendix PDF pages at marker positions and merges the TOC
+  hierarchically, tracking each marker's final page index for redaction.
 
-- Calculates precise overlay rectangles using marker position + table dimensions
-- Applies content-aware cropping to source PDFs (unless `crop=false`)
-- Overlays selected pages sequentially for multi-page selections
-- Removes markers using redaction (white fill)
+### 7. Finalization
 
-**Merge Processing (Paragraph-based):**
-```python
-merge_processor.process_merges(base_pdf_path, content_map, toc_pages, output_path)
-```
-
-- Inserts complete PDF pages at marker positions
-- Maintains document flow and pagination
-- Merges Table of Contents entries hierarchically
-- Handles page numbering and reference updates
-
-### 8. Finalization
-
-- Removes all temporary files (unless `--keep-temp` specified)
-- Validates final PDF integrity
-- Reports success/failure with detailed logging
+- Redacts placement markers on their (post-merge) pages and performs the single
+  document save (the only `garbage=4, deflate, clean` pass).
+- Removes all temporary files (unless `--keep-temp` specified).
+- Reports success/failure with detailed logging.
 
 ## Key Technical Details
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "python-docx>=1.2.0",
     "PyMuPDF>=1.26.3",
     "typer>=0.9.0",
+    "rich>=13.0.0",
     "pywin32; sys_platform == 'win32'",
     "questionary>=2.0.1",
 ]

--- a/src/report_compiler/cli.py
+++ b/src/report_compiler/cli.py
@@ -9,6 +9,7 @@ import typer
 
 from report_compiler.core.compiler import ReportCompiler
 from report_compiler.utils.logging_config import setup_logging, get_logger
+from report_compiler.utils.progress import ProgressReporter
 from report_compiler.utils.pdf_to_svg import PdfToSvgConverter
 from report_compiler.utils.word_integration_manager import WordIntegrationManager
 from report_compiler._version import __version__
@@ -60,6 +61,7 @@ def compile_docx(
     keep_temp: bool = typer.Option(False, help="Keep temporary files for debugging"),
     verbose: bool = typer.Option(False, "-v", "--verbose", "--debug", help="Enable verbose logging (DEBUG level)"),
     log_file: str = typer.Option(None, help="Log to file in addition to console"),
+    no_progress: bool = typer.Option(False, "--no-progress", help="Disable the live progress indicator"),
     version: bool = typer.Option(False, "--version", callback=version_callback, is_eager=True, help="Show version and exit")
 ):
     """Compile DOCX to PDF."""
@@ -68,7 +70,7 @@ def compile_docx(
     logger.info("=" * 60)
     logger.info(f"Report Compiler v{__version__} - Starting compilation")
     logger.info("=" * 60)
-    return handle_compilation(input_file, output_file, keep_temp, logger)
+    return handle_compilation(input_file, output_file, keep_temp, logger, show_progress=not no_progress)
 
 @app.command("svg-import")
 def svg_import(
@@ -349,7 +351,7 @@ def handle_svg_import(input_file, output_file, page, logger) -> int:
             logger.error("=" * 60)
             return 1
 
-def handle_compilation(input_file, output_file, keep_temp, logger) -> int:
+def handle_compilation(input_file, output_file, keep_temp, logger, show_progress: bool = True) -> int:
     """Handle the traditional DOCX compilation."""
     logger.info("Mode: DOCX compilation")
     
@@ -377,15 +379,20 @@ def handle_compilation(input_file, output_file, keep_temp, logger) -> int:
     
     # Run the report compiler
     compiler = None
+    # Only drive the live indicator on an interactive terminal; otherwise it
+    # would emit control sequences into piped/redirected output.
+    progress_enabled = show_progress and sys.stdout.isatty()
     try:
-        compiler = ReportCompiler(
-            input_path=str(input_path.absolute()),
-            output_path=str(output_path.absolute()),
-            keep_temp=keep_temp
-        )
-        
-        success = compiler.run()
-        
+        with ProgressReporter(enabled=progress_enabled) as progress:
+            compiler = ReportCompiler(
+                input_path=str(input_path.absolute()),
+                output_path=str(output_path.absolute()),
+                keep_temp=keep_temp,
+                progress=progress
+            )
+
+            success = compiler.run()
+
         if success:
             logger.info("=" * 60)
             logger.info("🎉 Report compilation completed successfully!")

--- a/src/report_compiler/core/compiler.py
+++ b/src/report_compiler/core/compiler.py
@@ -22,12 +22,13 @@ from ..pdf.overlay_processor import OverlayProcessor
 from ..pdf.merge_processor import MergeProcessor
 from ..pdf.marker_remover import MarkerRemover
 from ..utils.logging_config import get_compiler_logger
+from ..utils.progress import ProgressReporter
 
 
 class ReportCompiler:
     """Main orchestrator class for report compilation."""
     
-    def __init__(self, input_path: str, output_path: str, keep_temp: bool = False, recursion_level: int = 0, file_manager: FileManager = None, word_converter: WordConverter = None):
+    def __init__(self, input_path: str, output_path: str, keep_temp: bool = False, recursion_level: int = 0, file_manager: FileManager = None, word_converter: WordConverter = None, progress: ProgressReporter = None):
         """
         Initialize the report compiler.
 
@@ -39,6 +40,8 @@ class ReportCompiler:
             file_manager: An existing file manager instance for shared state.
             word_converter: An existing Word converter to reuse across recursive
                 compiles, so a single Word/COM instance serves the whole run.
+            progress: Shared progress reporter for the live status indicator.
+                Defaults to a disabled (no-op) reporter when not supplied.
         """
         self.input_path = os.path.abspath(input_path)
         self.output_path = os.path.abspath(output_path)
@@ -53,6 +56,7 @@ class ReportCompiler:
         self.content_analyzer = ContentAnalyzer()
         self.docx_processor = DocxProcessor()
         self.word_converter = word_converter if word_converter else WordConverter()
+        self.progress = progress if progress is not None else ProgressReporter(enabled=False)
         self.libreoffice_converter = LibreOfficeConverter()
         self.overlay_processor = OverlayProcessor()
         self.merge_processor = MergeProcessor()
@@ -88,6 +92,7 @@ class ReportCompiler:
         processed_files.add(self.input_path)
 
         self.logger.info(f"--- Starting Compilation for: {os.path.basename(self.input_path)} (Depth: {self.recursion_level}) ---")
+        self.progress.enter_document(os.path.basename(self.input_path))
 
         try:
             # The 'with' statement for file_manager is only used by the top-level call
@@ -96,12 +101,12 @@ class ReportCompiler:
                     result = self._execute_pipeline(processed_files)
             else:
                 result = self._execute_pipeline(processed_files)
-            
+
             if result:
                 self.logger.info(f"--- Finished Compilation for: {os.path.basename(self.input_path)} ---")
             else:
                 self.logger.error(f"--- Failed Compilation for: {os.path.basename(self.input_path)} ---")
-            
+
             return result
 
         except Exception as e:
@@ -110,6 +115,7 @@ class ReportCompiler:
         finally:
             # Ensure the shared base PDF document is always released, even on error.
             self._close_pdf_doc()
+            self.progress.exit_document()
             # Remove from set so sibling branches in the recursion tree can refer to this file
             if self.input_path in processed_files:
                 processed_files.remove(self.input_path)
@@ -128,19 +134,31 @@ class ReportCompiler:
             self.pdf_doc = None
 
     def _execute_pipeline(self, processed_files: Set[str]) -> bool:
-        """The core sequence of compilation steps."""
-        if not self._initialize(): return False
-        if not self._validate_paths(): return False
-        if not self._copy_input_to_temp(): return False
-        if not self._find_placeholders(): return False
-        if not self._resolve_docx_inserts(processed_files): return False
-        if not self._validate_placeholders(): return False
-        if not self._modify_docx(): return False
-        if not self._convert_to_pdf(): return False
-        if not self._analyze_base_pdf(): return False
-        if not self._process_pdf_overlays(): return False
-        if not self._process_pdf_merges(): return False
-        if not self._finalize_pdf(): return False
+        """The core sequence of compilation steps.
+
+        Stages are driven from a single table so the live progress indicator and
+        the per-stage log headers stay in lock-step (and the stage count has one
+        source of truth).
+        """
+        stages = [
+            ("Initialization", self._initialize),
+            ("Path Validation", self._validate_paths),
+            ("Copy Input", self._copy_input_to_temp),
+            ("Find Placeholders", self._find_placeholders),
+            ("Recursive DOCX Resolution", lambda: self._resolve_docx_inserts(processed_files)),
+            ("Validate Placeholders", self._validate_placeholders),
+            ("DOCX Modification", self._modify_docx),
+            ("PDF Conversion", self._convert_to_pdf),
+            ("PDF Analysis", self._analyze_base_pdf),
+            ("PDF Overlays", self._process_pdf_overlays),
+            ("PDF Merging", self._process_pdf_merges),
+            ("Finalization", self._finalize_pdf),
+        ]
+        total = len(stages)
+        for num, (name, step) in enumerate(stages, 1):
+            self.progress.set_stage(num, total, name)
+            if not step():
+                return False
         if self.recursion_level == 0:
             self.logger.info(f"\n{self._log_prefix()}=== Report Compilation Successful ===")
         return True
@@ -278,7 +296,8 @@ class ReportCompiler:
                 keep_temp=self.keep_temp,
                 recursion_level=self.recursion_level + 1,
                 file_manager=self.file_manager,
-                word_converter=self.word_converter
+                word_converter=self.word_converter,
+                progress=self.progress
             )
 
             if not sub_compiler.run(processed_files):

--- a/src/report_compiler/core/compiler.py
+++ b/src/report_compiler/core/compiler.py
@@ -9,6 +9,8 @@ import logging
 import os
 from typing import Set
 
+import fitz  # PyMuPDF
+
 from ..utils.file_manager import FileManager
 from ..utils.validators import Validators
 from ..document.placeholder_parser import PlaceholderParser
@@ -25,35 +27,37 @@ from ..utils.logging_config import get_compiler_logger
 class ReportCompiler:
     """Main orchestrator class for report compilation."""
     
-    def __init__(self, input_path: str, output_path: str, keep_temp: bool = False, recursion_level: int = 0, file_manager: FileManager = None):
+    def __init__(self, input_path: str, output_path: str, keep_temp: bool = False, recursion_level: int = 0, file_manager: FileManager = None, word_converter: WordConverter = None):
         """
         Initialize the report compiler.
-        
+
         Args:
             input_path: Path to input DOCX file.
             output_path: Path for output PDF file.
             keep_temp: Whether to keep temporary files for debugging.
             recursion_level: The current recursion depth.
             file_manager: An existing file manager instance for shared state.
+            word_converter: An existing Word converter to reuse across recursive
+                compiles, so a single Word/COM instance serves the whole run.
         """
         self.input_path = os.path.abspath(input_path)
         self.output_path = os.path.abspath(output_path)
         self.keep_temp = keep_temp
         self.recursion_level = recursion_level
         self.logger = get_compiler_logger()
-        
+
         # Initialize components
         self.file_manager = file_manager if file_manager else FileManager(keep_temp)
         self.validators = Validators()
         self.placeholder_parser = PlaceholderParser()
         self.content_analyzer = ContentAnalyzer()
         self.docx_processor = DocxProcessor()
-        self.word_converter = WordConverter()
+        self.word_converter = word_converter if word_converter else WordConverter()
         self.libreoffice_converter = LibreOfficeConverter()
         self.overlay_processor = OverlayProcessor()
         self.merge_processor = MergeProcessor()
         self.marker_remover = MarkerRemover()
-        
+
         # Process state
         self.placeholders = {}
         self.base_directory = os.path.dirname(self.input_path)
@@ -63,10 +67,10 @@ class ReportCompiler:
         self.temp_docx_path = None
         self.temp_pdf_path = None
         self.final_pdf_path = None
-        self.overlay_pdf_path = None
-        self.merged_pdf_path = None
-        self.toc_pages = []
         self.content_map = {}
+        # The base PDF is opened once and shared across the overlay, merge and
+        # marker-removal stages, then saved exactly once during finalization.
+        self.pdf_doc = None
 
     def _log_prefix(self) -> str:
         """Provides a prefix for logging based on recursion depth."""
@@ -104,9 +108,24 @@ class ReportCompiler:
             self.logger.error(f"{self._log_prefix()}❌ A critical error occurred: %s", e, exc_info=True)
             return False
         finally:
+            # Ensure the shared base PDF document is always released, even on error.
+            self._close_pdf_doc()
             # Remove from set so sibling branches in the recursion tree can refer to this file
             if self.input_path in processed_files:
                 processed_files.remove(self.input_path)
+
+    def _close_pdf_doc(self) -> None:
+        """Close the shared base PDF document and any overlay sources if still open."""
+        try:
+            self.overlay_processor.close_sources()
+        except Exception:
+            pass
+        if self.pdf_doc is not None:
+            try:
+                self.pdf_doc.close()
+            except Exception:
+                pass
+            self.pdf_doc = None
 
     def _execute_pipeline(self, processed_files: Set[str]) -> bool:
         """The core sequence of compilation steps."""
@@ -133,13 +152,11 @@ class ReportCompiler:
         # Use a more specific name for the base PDF to avoid collisions in recursion
         base_pdf_suffix = f"base_{self.recursion_level}"
         self.temp_pdf_path = self.file_manager.generate_temp_path(self.output_path, base_pdf_suffix)
-        self.overlay_pdf_path = self.file_manager.generate_temp_path(self.output_path, f"with_overlays_{self.recursion_level}")
         self.final_pdf_path = self.output_path
         self.logger.debug(f"{self._log_prefix()}  > Input DOCX: {self.input_path}")
         self.logger.debug(f"{self._log_prefix()}  > Output PDF: {self.final_pdf_path}")
         self.logger.debug(f"{self._log_prefix()}  > Temp DOCX: {self.temp_docx_path}")
         self.logger.debug(f"{self._log_prefix()}  > Temp PDF (Base): {self.temp_pdf_path}")
-        self.logger.debug(f"{self._log_prefix()}  > Temp PDF (Overlaid): {self.overlay_pdf_path}")
         self.logger.info(f"{self._log_prefix()}  > Environment initialized.")
         return True
 
@@ -260,7 +277,8 @@ class ReportCompiler:
                 output_path=temp_output_pdf,
                 keep_temp=self.keep_temp,
                 recursion_level=self.recursion_level + 1,
-                file_manager=self.file_manager
+                file_manager=self.file_manager,
+                word_converter=self.word_converter
             )
 
             if not sub_compiler.run(processed_files):
@@ -308,22 +326,19 @@ class ReportCompiler:
             return True
 
         self.logger.info(f"{self._log_prefix()}  > Inserting markers into DOCX for {self.placeholders['total']} placeholders...")
-        # Create a new temp file for the modified version to avoid overwriting the original temp copy
-        modified_temp_path = self.file_manager.generate_temp_path(self.input_path, "modified_with_markers")
+        # Reuse the document already parsed during placeholder detection instead of
+        # re-parsing the same file, and save the modified version straight over the
+        # temp copy (python-docx holds the file in memory, so the read handle is
+        # already closed) — no extra intermediate file or move is needed.
+        preloaded_doc = self.placeholder_parser.get_loaded_document(self.temp_docx_path)
         table_metadata = self.docx_processor.create_modified_docx(
-            self.temp_docx_path, self.placeholders, modified_temp_path
+            self.temp_docx_path, self.placeholders, self.temp_docx_path, doc=preloaded_doc
         )
 
         if table_metadata is None:
             self.logger.error(f"{self._log_prefix()}  > ❌ Failed to create modified DOCX.")
             return False
 
-        # Replace the temp file with the modified version
-        move_success = self.file_manager.move_file(modified_temp_path, self.temp_docx_path)
-        if not move_success:
-            self.logger.error(f"{self._log_prefix()}  > ❌ Failed to replace temp file with modified version.")
-            return False
-            
         self.table_metadata = table_metadata
         self.logger.info(f"{self._log_prefix()}  > Modified DOCX created successfully.")
         return True
@@ -379,14 +394,19 @@ class ReportCompiler:
             return True
 
         self.logger.info(f"{self._log_prefix()}  > Analyzing base PDF for content and markers...")
-        analysis_result = self.content_analyzer.analyze(
-            self.temp_pdf_path, self.placeholders, self.table_metadata
+        # Open the base PDF once. The same document object is carried through the
+        # overlay, merge and marker-removal stages and saved a single time during
+        # finalization, avoiding repeated parse/serialize round-trips and the
+        # intermediate "with_overlays" and "merged" PDF files.
+        self.pdf_doc = fitz.open(self.temp_pdf_path)
+        content_map = self.content_analyzer.analyze(
+            self.pdf_doc, self.placeholders, self.table_metadata
         )
-        if not analysis_result:
+        if content_map is None:
             self.logger.error(f"{self._log_prefix()}  > ❌ PDF analysis failed.")
             return False
-        
-        self.content_map, self.toc_pages = analysis_result
+
+        self.content_map = content_map
         self.logger.info(f"{self._log_prefix()}  > PDF analysis complete.")
         # The full content map contains every placeholder's nested metadata
         # (resolved paths, table text, dims) repeated per page and can be many
@@ -395,40 +415,36 @@ class ReportCompiler:
         if self.logger.isEnabledFor(logging.DEBUG):
             marker_pages = {m: d.get('page_index') for m, d in self.content_map.items()}
             self.logger.debug(f"{self._log_prefix()}  > Content map (marker -> page index): {marker_pages}")
-            self.logger.debug(f"{self._log_prefix()}  > TOC Pages: {self.toc_pages}")
         return True
 
     def _process_pdf_overlays(self) -> bool:
-        """[Stage 10/12: PDF Overlays] Apply overlays to the base PDF."""
+        """[Stage 10/12: PDF Overlays] Apply overlays to the base PDF (in memory)."""
         self.logger.info(f"{self._log_prefix()}[Stage 10/12: PDF Overlays]")
-        
+
         table_placeholders = self.placeholders.get('table', [])
         if not table_placeholders:
             self.logger.info(f"{self._log_prefix()}  > No table placeholders to process as overlays. Skipping.")
-            self.file_manager.copy_file(self.temp_pdf_path, self.overlay_pdf_path)
             return True
 
         self.logger.info(f"{self._log_prefix()}  > Processing overlays...")
         success = self.overlay_processor.process_overlays(
-            base_pdf_path=self.temp_pdf_path,
-            output_path=self.overlay_pdf_path,
+            base_doc=self.pdf_doc,
             content_map=self.content_map
         )
         if not success:
             self.logger.error(f"{self._log_prefix()}  > ❌ Failed to process overlays.")
             return False
-        
+
         self.logger.info(f"{self._log_prefix()}  > Overlays processed successfully.")
         return True
 
     def _process_pdf_merges(self) -> bool:
-        """[Stage 11/12: PDF Merging] Merge inserted PDFs into the main document."""
+        """[Stage 11/12: PDF Merging] Merge inserted PDFs into the main document (in memory)."""
         self.logger.info(f"{self._log_prefix()}[Stage 11/12: PDF Merging]")
-        
+
         paragraph_placeholders = self.placeholders.get('paragraph', [])
         if not paragraph_placeholders:
             self.logger.info(f"{self._log_prefix()}  > No paragraph placeholders to merge. Skipping.")
-            # The overlay_pdf_path is carried forward to the finalization step
             return True
 
         if not self.content_map:
@@ -436,57 +452,55 @@ class ReportCompiler:
             return False
 
         self.logger.info(f"{self._log_prefix()}  > Merging PDF inserts...")
-        # The final PDF before marker removal is created here.
-        self.merged_pdf_path = self.file_manager.generate_temp_path(self.output_path, "merged")
-        
         success = self.merge_processor.process_merges(
-            base_pdf_path=self.overlay_pdf_path,
-            output_path=self.merged_pdf_path,
-            content_map=self.content_map,
-            toc_pages=self.toc_pages
+            output_doc=self.pdf_doc,
+            content_map=self.content_map
         )
         if not success:
             self.logger.error(f"{self._log_prefix()}  > ❌ Failed to merge PDFs.")
             return False
-        
+
         self.logger.info(f"{self._log_prefix()}  > PDF inserts merged successfully.")
         return True
 
     def _finalize_pdf(self) -> bool:
-        """[Stage 12/12: Finalization] Remove markers and save the final PDF."""
+        """[Stage 12/12: Finalization] Remove markers and save the final PDF once."""
         self.logger.info(f"{self._log_prefix()}[Stage 12/12: Finalization]")
-        
-        # If no placeholders were processed, the final PDF is already in place.
+
+        # If no placeholders were processed, the final PDF is already in place
+        # (copied during analysis); nothing was opened in memory.
         if self.placeholders['total'] == 0:
             self.logger.info(f"{self._log_prefix()}  > No markers to remove. Final PDF is ready.")
-            if self.recursion_level > 0:
-                 self.file_manager.copy_file(self.temp_pdf_path, self.output_path)
             return True
-
-        # Determine the source PDF for marker removal
-        source_pdf_for_removal = self.merged_pdf_path if self.merged_pdf_path else self.overlay_pdf_path
 
         self.logger.info(f"{self._log_prefix()}  > Removing markers from the final PDF...")
         all_markers = list(self.content_map.keys())
 
-        # Determine each marker's page in the PDF being cleaned so the remover can
-        # target specific pages instead of scanning the whole document per marker.
-        # If a merge happened, page indices shifted and the merge processor knows
-        # the final positions; otherwise content-map indices are still accurate.
-        if self.merged_pdf_path:
+        # Determine each marker's page in the document so the remover can target
+        # specific pages instead of scanning the whole document per marker. If a
+        # merge happened, page indices shifted and the merge processor knows the
+        # final positions; otherwise content-map indices are still accurate.
+        if self.placeholders.get('paragraph') and self.merge_processor.final_marker_pages:
             marker_pages = self.merge_processor.final_marker_pages
         else:
             marker_pages = {m: d['page_index'] for m, d in self.content_map.items()}
 
         success = self.marker_remover.remove_markers(
-            input_pdf_path=source_pdf_for_removal,
+            pdf_document=self.pdf_doc,
             markers=all_markers,
-            output_pdf_path=self.final_pdf_path,
             marker_pages=marker_pages
         )
         if not success:
             self.logger.error(f"{self._log_prefix()}  > ❌ Failed to remove markers from the final PDF.")
             return False
-        
+
+        # Single save of the fully assembled document: garbage-collect, deflate and
+        # clean only once (previously done on both the merge and the finalize saves).
+        self.logger.info(f"{self._log_prefix()}  > Saving final PDF...")
+        self.pdf_doc.save(self.final_pdf_path, garbage=4, deflate=True, clean=True)
+        # Release the document and the overlay sources (which show_pdf_page() may
+        # reference until the save above completes) now that the save is done.
+        self._close_pdf_doc()
+
         self.logger.info(f"{self._log_prefix()}  > ✓ Final PDF created at: {self.final_pdf_path}")
         return True

--- a/src/report_compiler/document/docx_processor.py
+++ b/src/report_compiler/document/docx_processor.py
@@ -20,22 +20,29 @@ class DocxProcessor:
         self.logger = get_docx_logger()
 
     def create_modified_docx(
-        self, input_path: str, placeholders: Dict[str, List[Dict]], output_path: str
+        self, input_path: str, placeholders: Dict[str, List[Dict]], output_path: str,
+        doc: Optional[Document] = None
     ) -> Optional[Dict[int, Dict[str, float]]]:
         """
         Create a modified DOCX, replacing placeholders with markers and extracting table dimensions.
 
         Args:
-            input_path: Path to the source DOCX file.
+            input_path: Path to the source DOCX file (used only if ``doc`` is None).
             placeholders: Dictionary of found placeholders.
             output_path: Path to save the modified DOCX.
+            doc: An already-loaded python-docx Document to modify in place. Passing
+                the document parsed during placeholder detection avoids a second
+                full parse of the same (potentially large) file.
 
         Returns:
             A dictionary mapping table indices to their dimensions, or None on failure.
         """
         try:
-            self.logger.debug("  > Loading source DOCX: %s", os.path.basename(input_path))
-            doc = Document(input_path)
+            if doc is None:
+                self.logger.debug("  > Loading source DOCX: %s", os.path.basename(input_path))
+                doc = Document(input_path)
+            else:
+                self.logger.debug("  > Reusing pre-parsed DOCX document.")
             table_metadata = {}
 
             # Process paragraph placeholders first

--- a/src/report_compiler/document/placeholder_parser.py
+++ b/src/report_compiler/document/placeholder_parser.py
@@ -42,6 +42,16 @@ class PlaceholderParser:
             'total': len(table_placeholders) + len(paragraph_placeholders)
         }
     
+    def get_loaded_document(self, docx_path: str):
+        """Return the parsed Document for ``docx_path`` if it is still cached.
+
+        Lets callers reuse the document parsed during placeholder detection
+        instead of re-parsing the same file.
+        """
+        if self._doc is not None and self._doc_path == docx_path:
+            return self._doc
+        return None
+
     def _load_document(self, docx_path: str) -> None:
         """Load document if not already loaded or path changed."""
         if self._doc is None or self._doc_path != docx_path:

--- a/src/report_compiler/document/word_converter.py
+++ b/src/report_compiler/document/word_converter.py
@@ -3,7 +3,6 @@ Word automation for DOCX to PDF conversion.
 """
 
 import os
-import time
 from typing import Optional
 from ..core.config import Config
 from ..utils.logging_config import get_logger
@@ -21,17 +20,26 @@ class WordConverter:
         self.word_app = None
         self.is_connected = False
         self.logger = get_logger()
+        self._available: Optional[bool] = None
 
     def is_available(self) -> bool:
-        """Checks if the Word application can be automated."""
+        """Checks if the Word application can be automated.
+
+        The result is memoized: probing availability dispatches a COM instance,
+        so for a multi-document (recursive) compile this avoids spinning up and
+        discarding a Word instance once per sub-document.
+        """
+        if self._available is not None:
+            return self._available
         if win32com is None:
+            self._available = False
             return False
-        # A lightweight check without launching the full app
         try:
             win32com.client.Dispatch("Word.Application")
-            return True
+            self._available = True
         except Exception:
-            return False
+            self._available = False
+        return self._available
     
     def connect(self) -> bool:
         """
@@ -88,8 +96,8 @@ class WordConverter:
             doc = self.word_app.Documents.Open(docx_path)
             
             self.logger.info("  > Updating document fields (e.g., Table of Contents)...")
+            # Fields.Update() is a synchronous COM call; no sleep is needed.
             doc.Fields.Update()
-            time.sleep(1) # Give Word a moment to update.
 
             self.logger.debug(f"  > Exporting to PDF: {os.path.basename(pdf_path)}")
             doc.ExportAsFixedFormat(

--- a/src/report_compiler/pdf/content_analyzer.py
+++ b/src/report_compiler/pdf/content_analyzer.py
@@ -15,93 +15,31 @@ class ContentAnalyzer:
     def __init__(self):
         self.logger = get_module_logger(__name__)
 
-    def find_toc_pages(self, pdf_path: str) -> list[int]:
-        """Identifies pages that appear to be a Table of Contents."""
-        toc_pages = []
-        try:
-            self.logger.debug("  > Scanning for Table of Contents...")
-            doc = fitz.open(pdf_path)
-            # A simple heuristic: look for pages with the title "Table of Contents"
-            for i, page in enumerate(doc):
-                if "table of contents" in page.get_text().lower():
-                    toc_pages.append(i)
-            return toc_pages
-        except Exception as e:
-            self.logger.error("  > ❌ Error analyzing for ToC pages: %s", e, exc_info=True)
-            return []
+    def _expected_markers(
+        self, placeholders: dict[str, Any], table_metadata: Optional[Dict[int, Any]]
+    ) -> dict[str, dict[str, Any]]:
+        """Build the set of markers we expect to find, keyed by marker string.
 
-    def find_placeholder_markers(
-        self, pdf_path: str, placeholders: dict[str, Any], table_metadata: dict[int, Any]
-    ) -> dict[str, Any]:
+        Each value carries everything needed to construct the content-map entry
+        once the marker's location is known. Table placeholders contribute one
+        marker per source page (matching the row replication done in the DOCX).
         """
-        Scans the PDF for all placeholder markers and records their locations and metadata.
-        Handles multi-page overlays by searching for each page's unique marker.
+        expected: dict[str, dict[str, Any]] = {}
 
-        Returns:
-            A content_map dictionary mapping a marker string to its location data.
-        """
-        content_map = {}
-        self.logger.debug("  > Scanning PDF for placeholder markers...")
-        try:
-            doc = fitz.open(pdf_path)
-            
-            # Process paragraph placeholders
-            for placeholder in placeholders.get('paragraph', []):
-                self._find_and_map_marker(doc, placeholder, content_map)
+        for placeholder in placeholders.get('paragraph', []):
+            marker = Config.get_merge_marker(placeholder['paragraph_index'])
+            expected[marker] = {'placeholder': placeholder, 'is_table': False}
 
-            # Process table placeholders, handling multi-page overlays
-            for placeholder in placeholders.get('table', []):
-                num_pages = placeholder.get('page_count', 1)
-                
-                for page_num in range(1, num_pages + 1):
-                    # For each page of the overlay, find its corresponding marker
-                    self._find_and_map_marker(doc, placeholder, content_map, table_metadata, page_num)
-
-            self.logger.debug("  > Found %d markers in total.", len(content_map))
-            return content_map
-        except Exception as e:
-            self.logger.error("❌ Error finding placeholder markers in PDF: %s", e, exc_info=True)
-            return {}
-
-    def _find_and_map_marker(self, doc: fitz.Document, placeholder: dict[str, Any], content_map: dict[str, Any], table_metadata: Optional[Dict[int, Any]] = None, page_num: int = 1):
-        """Helper to find a single marker and add it to the content map."""
-        marker = self._get_marker_for_placeholder(placeholder, page_num)
-        if not marker:
-            return
-
-        found_marker = self._search_for_marker_in_doc(doc, marker)
-        if found_marker:
-            page_index, rect = found_marker
-            self.logger.debug("    - Found marker '%s' on page %d at (%.2f, %.2f) inches.",
-                             marker, page_index + 1, points_to_inches(rect.x0), points_to_inches(rect.y0))
-            
-            map_entry = {
-                'placeholder': placeholder,
-                'page_index': page_index,
-                'rect': [rect.x0, rect.y0, rect.x1, rect.y1],
-                'type': placeholder['type']
-            }
-            if placeholder['type'] == 'table':
+        for placeholder in placeholders.get('table', []):
+            num_pages = placeholder.get('page_count', 1)
+            for page_num in range(1, num_pages + 1):
+                marker = Config.get_overlay_marker(placeholder['table_index'], page_num)
+                entry = {'placeholder': placeholder, 'is_table': True, 'overlay_page_num': page_num}
                 if table_metadata:
-                    map_entry['table_dims'] = table_metadata.get(placeholder['table_index'], {})
-                map_entry['overlay_page_num'] = page_num # Add the overlay page number
-            content_map[marker] = map_entry
-        else:
-            self.logger.warning("    - ⚠️ Marker '%s' not found in the PDF.", marker)
+                    entry['table_dims'] = table_metadata.get(placeholder['table_index'], {})
+                expected[marker] = entry
 
-    def _get_marker_for_placeholder(self, placeholder: dict[str, Any], page_num: int = 1) -> Optional[str]:
-        if placeholder.get('type') == 'table':
-            return Config.get_overlay_marker(placeholder['table_index'], page_num)
-        elif placeholder.get('type') == 'paragraph':
-            return Config.get_merge_marker(placeholder['paragraph_index'])
-        return None
-
-    def _search_for_marker_in_doc(self, doc: fitz.Document, marker: str) -> Optional[tuple[int, fitz.Rect]]:
-        for page_index, page in enumerate(doc):
-            rects = page.search_for(marker)
-            if rects:
-                return page_index, rects[0]  # Return page and rect of first find
-        return None
+        return expected
 
     def get_content_bbox(self, pdf_page: fitz.Page) -> Optional[fitz.Rect]:
         """
@@ -205,31 +143,65 @@ class ContentAnalyzer:
         self.logger.debug("  > Baking annotations for %d pages...", len(pdf_doc))
         pdf_doc.bake(annots=True)  # Apply all annotations across the whole document
 
-    def analyze(self, pdf_path: str, placeholders: dict[str, Any], table_metadata: dict[int, Any]) -> Optional[tuple[dict[str, Any], list[int]]]:
+    def analyze(self, pdf_doc: fitz.Document, placeholders: dict[str, Any], table_metadata: dict[int, Any]) -> Optional[dict[str, Any]]:
         """
-        Analyzes the PDF to find all markers and the table of contents.
+        Locate every placeholder marker in the (already open) base PDF.
+
+        This is a single sweep over the document: each page is visited once and
+        searched for any markers not yet found, short-circuiting as soon as all
+        expected markers are located. This replaces the previous approach which
+        opened the PDF twice and scanned the whole document once per marker
+        (O(markers x pages)), plus a separate full-text sweep for a Table of
+        Contents that nothing downstream consumed.
 
         Args:
-            pdf_path: Path to the PDF file.
+            pdf_doc: An open PyMuPDF document for the base PDF.
             placeholders: Dictionary of placeholders.
             table_metadata: Dictionary of table metadata.
 
         Returns:
-            A tuple containing the content_map and a list of TOC page indices, or None on failure.
+            A content_map dictionary mapping each found marker to its location
+            data, or None on failure.
         """
         self.logger.info("  > Starting PDF analysis...")
-        
-        try:
-            toc_pages = self.find_toc_pages(pdf_path)
-            self.logger.info("  > Found %d Table of Contents pages.", len(toc_pages))
 
-            content_map = self.find_placeholder_markers(pdf_path, placeholders, table_metadata)
+        try:
+            pending = self._expected_markers(placeholders, table_metadata)
+            content_map: dict[str, Any] = {}
+
+            for page_index, page in enumerate(pdf_doc):
+                if not pending:
+                    break  # Every expected marker has been located.
+                for marker in list(pending.keys()):
+                    rects = page.search_for(marker)
+                    if not rects:
+                        continue
+                    rect = rects[0]
+                    info = pending.pop(marker)
+                    self.logger.debug("    - Found marker '%s' on page %d at (%.2f, %.2f) inches.",
+                                     marker, page_index + 1,
+                                     points_to_inches(rect.x0), points_to_inches(rect.y0))
+                    map_entry = {
+                        'placeholder': info['placeholder'],
+                        'page_index': page_index,
+                        'rect': [rect.x0, rect.y0, rect.x1, rect.y1],
+                        'type': info['placeholder']['type'],
+                    }
+                    if info['is_table']:
+                        if 'table_dims' in info:
+                            map_entry['table_dims'] = info['table_dims']
+                        map_entry['overlay_page_num'] = info['overlay_page_num']
+                    content_map[marker] = map_entry
+
+            for marker in pending:
+                self.logger.warning("    - ⚠️ Marker '%s' not found in the PDF.", marker)
+
             if not content_map and placeholders.get('total', 0) > 0:
                 # This can happen if the DOCX modification failed to insert markers, or if they were removed during PDF conversion.
                 self.logger.warning("  > ⚠️ No markers were found in the PDF, but placeholders were expected. Downstream processing may fail.")
 
-            self.logger.info("  > PDF analysis complete.")
-            return content_map, toc_pages
+            self.logger.info("  > PDF analysis complete (%d markers located).", len(content_map))
+            return content_map
         except Exception as e:
             self.logger.error("❌ Top-level error during PDF analysis: %s", e, exc_info=True)
             return None

--- a/src/report_compiler/pdf/marker_remover.py
+++ b/src/report_compiler/pdf/marker_remover.py
@@ -13,17 +13,19 @@ class MarkerRemover:
     def __init__(self):
         self.logger = get_module_logger(__name__)
 
-    def remove_markers(self, input_pdf_path: str, markers: list[str], output_pdf_path: str,
+    def remove_markers(self, pdf_document: fitz.Document, markers: list[str],
                        marker_pages: Optional[Dict[str, int]] = None) -> bool:
         """
-        Removes all specified markers from the PDF by redacting each marker text.
+        Removes all specified markers from the open PDF by redacting each marker text.
+
+        The document is modified in place and is not saved here; the caller owns
+        its lifecycle and performs the single final save.
 
         Args:
-            input_pdf_path: Path to the input PDF file.
+            pdf_document: The open PDF document to redact markers from.
             markers: A list of marker strings to remove.
-            output_pdf_path: Path to save the cleaned PDF file.
             marker_pages: Optional mapping of marker -> known 0-based page index in
-                the input PDF. When supplied (and complete), only those pages are
+                the document. When supplied (and complete), only those pages are
                 searched instead of scanning every page for every marker, which is
                 far cheaper on large documents. Falls back to a full scan if the
                 map is missing or incomplete.
@@ -31,9 +33,8 @@ class MarkerRemover:
         Returns:
             True if successful, False otherwise.
         """
-        self.logger.debug("      Removing %d markers from '%s'...", len(markers), input_pdf_path)
+        self.logger.debug("      Removing %d markers...", len(markers))
         try:
-            pdf_document = fitz.open(input_pdf_path)
             # Redaction options that leave images and vector line-art untouched.
             # The markers are tiny text strings; without these flags every
             # apply_redactions() call reprocesses all images/graphics on the page,
@@ -54,9 +55,7 @@ class MarkerRemover:
                 for page in pdf_document:
                     self._redact_markers_on_page(page, markers, redact_kwargs)
 
-            pdf_document.save(output_pdf_path, garbage=4, deflate=True, clean=True)
-            pdf_document.close()
-            self.logger.debug("      Markers removed. Cleaned PDF saved to '%s'", output_pdf_path)
+            self.logger.debug("      Markers redacted.")
             return True
         except Exception as e:
             self.logger.error("      ❌ Error during marker removal: %s", e, exc_info=True)

--- a/src/report_compiler/pdf/merge_processor.py
+++ b/src/report_compiler/pdf/merge_processor.py
@@ -3,7 +3,6 @@ PDF merge processing for paragraph-based insertions.
 """
 
 import fitz  # PyMuPDF
-import shutil
 import os
 from typing import Dict, List, Any, Optional
 from ..utils.page_selector import PageSelector
@@ -23,16 +22,18 @@ class MergeProcessor:
         # scanning every page.
         self.final_marker_pages: Dict[str, int] = {}
 
-    def process_merges(self, base_pdf_path: str, content_map: Dict[str, Any],
-                       toc_pages: List[int], output_path: str) -> bool:
+    def process_merges(self, output_doc: fitz.Document, content_map: Dict[str, Any]) -> bool:
         """
         Process all merge placeholders, inserting PDFs and creating a hierarchical TOC.
 
+        Inserts content directly into the open document. The document is neither
+        opened nor saved here; the caller owns its lifecycle so overlay, merge,
+        and marker removal can share a single open document and a single save.
+
         Args:
-            base_pdf_path: Path to the PDF to insert content into.
+            output_doc: The open document (already carrying any overlays) to
+                insert appendix content into.
             content_map: Dictionary mapping markers to their location and metadata.
-            toc_pages: A list of page numbers that contain the Table of Contents.
-            output_path: Path for the final output PDF.
 
         Returns:
             True if successful, False otherwise.
@@ -44,13 +45,9 @@ class MergeProcessor:
 
         if not merge_markers:
             self.logger.info("No merge placeholders to process.")
-            if os.path.exists(base_pdf_path) and not os.path.samefile(base_pdf_path, output_path):
-                shutil.copy(base_pdf_path, output_path)
             return True
 
         try:
-            self.logger.debug("Opening base PDF for merging: %s", base_pdf_path)
-            output_doc = fitz.open(base_pdf_path)
             master_toc = output_doc.get_toc(simple=False)
             self.logger.debug("  > Extracted %d root TOC entries from base document.", len(master_toc))
 
@@ -139,18 +136,12 @@ class MergeProcessor:
 
             self.logger.info("  > Applying final hierarchical Table of Contents.")
             output_doc.set_toc(master_toc)
-            
-            self.logger.debug("Saving final merged PDF to: %s", output_path)
-            output_doc.save(output_path, garbage=3, deflate=True, clean=True)
             self.logger.info("✓ Merge processing complete.")
             return True
 
         except Exception as e:
             self.logger.error("❌ Error during merge processing: %s", e, exc_info=True)
             return False
-        finally:
-            if 'output_doc' in locals() and output_doc and not output_doc.is_closed:
-                output_doc.close()
 
     def _merge_toc_entries(self, master_toc, appendix_toc, marker_page_num, new_content_start_page_num, placeholder, marker_rect: Optional[List[float]]):
         """Finds the correct position in the master TOC and inserts the appendix TOC."""

--- a/src/report_compiler/pdf/overlay_processor.py
+++ b/src/report_compiler/pdf/overlay_processor.py
@@ -17,16 +17,24 @@ class OverlayProcessor:
         self.page_selector = PageSelector()
         self.content_analyzer = ContentAnalyzer()
         self.logger = get_overlay_logger()
+        # Opened source documents are kept alive here until close_sources() is
+        # called. show_pdf_page() can keep referencing the source document until
+        # the target is saved, so the caller must close these only after the
+        # final save of the base document.
+        self._source_doc_cache: Dict[str, fitz.Document] = {}
         self.logger.debug("PyMuPDF (fitz) version: %s, path: %s", fitz.__version__, fitz.__file__)
 
-    def process_overlays(self, base_pdf_path: str, content_map: Dict[str, Any], output_path: str) -> bool:
+    def process_overlays(self, base_doc: fitz.Document, content_map: Dict[str, Any]) -> bool:
         """
-        Process all overlay placeholders in the base PDF.
+        Process all overlay placeholders directly on the open base document.
+
+        The document is modified in place and is neither opened nor saved here;
+        the caller owns its lifecycle so that overlay, merge, and marker removal
+        can share a single open document and a single final save.
 
         Args:
-            base_pdf_path: Path to base PDF document.
+            base_doc: The open base PDF document to overlay content onto.
             content_map: Dictionary mapping markers to their location and metadata.
-            output_path: Path for output PDF.
 
         Returns:
             bool: True if successful, False otherwise.
@@ -38,14 +46,13 @@ class OverlayProcessor:
 
         if not overlay_markers:
             self.logger.info("No overlay placeholders to process.")
-            # If no overlays, the output is just a copy of the input
-            # This is handled by the compiler's file management.
             return True
 
         # Cache of opened+baked source documents keyed by resolved path. The same
         # source PDF is typically referenced by many markers (one per page), so
         # opening and baking it once and reusing it avoids O(markers x pages) work.
-        source_doc_cache: Dict[str, fitz.Document] = {}
+        # Kept open until close_sources() so the base document can be saved first.
+        source_doc_cache = self._source_doc_cache
         # Cache of computed content-crop rectangles keyed by (path, source_page_idx).
         crop_rect_cache: Dict[Any, fitz.Rect] = {}
         # Cache of resolved source-page selections keyed by (path, page_spec). The
@@ -53,30 +60,32 @@ class OverlayProcessor:
         selection_cache: Dict[Any, List[int]] = {}
 
         try:
-            self.logger.debug("Opening base PDF: %s", base_pdf_path)
-            with fitz.open(base_pdf_path) as base_doc:
-                for idx, (marker, data) in enumerate(overlay_markers.items(), 1):
-                    if not self._process_single_overlay(
-                        base_doc, marker, data, idx,
-                        source_doc_cache, crop_rect_cache, selection_cache
-                    ):
-                        return False
+            for idx, (marker, data) in enumerate(overlay_markers.items(), 1):
+                if not self._process_single_overlay(
+                    base_doc, marker, data, idx,
+                    source_doc_cache, crop_rect_cache, selection_cache
+                ):
+                    return False
 
-                self.logger.debug("Saving overlaid PDF to: %s", output_path)
-                base_doc.save(output_path)
-                self.logger.info("✓ Overlaid PDF saved successfully.")
-
+            self.logger.info("✓ Overlays applied successfully.")
             return True
 
         except Exception as e:
             self.logger.error("❌ Error during overlay processing: %s", e, exc_info=True)
             return False
-        finally:
-            for src in source_doc_cache.values():
-                try:
-                    src.close()
-                except Exception:
-                    pass
+
+    def close_sources(self) -> None:
+        """Close all cached overlay source documents.
+
+        Must be called only after the base document has been saved, because
+        show_pdf_page() may reference these sources until that save completes.
+        """
+        for src in self._source_doc_cache.values():
+            try:
+                src.close()
+            except Exception:
+                pass
+        self._source_doc_cache.clear()
 
     def _get_source_doc(self, pdf_path: str,
                         source_doc_cache: Dict[str, fitz.Document]) -> fitz.Document:

--- a/src/report_compiler/utils/progress.py
+++ b/src/report_compiler/utils/progress.py
@@ -1,0 +1,210 @@
+"""
+Live terminal progress indicator that coexists with the scrolling logs.
+
+The compiler emits detailed INFO logs as it works. This module pins a small,
+continuously refreshing status region to the bottom of the terminal that shows:
+
+  * a spinner (so the user can see work is ongoing during long, opaque steps
+    like the Word conversion or the final PDF save),
+  * the recursion breadcrumb and depth (which nested document is compiling),
+  * the current pipeline stage (e.g. ``Stage 8/12 - PDF Conversion``),
+  * elapsed time.
+
+Log lines are routed through the same rich console so they print *above* the
+live region instead of corrupting it. File logging (``--log-file``) is left
+completely untouched.
+
+The reporter degrades to a no-op when disabled (e.g. output is not a TTY) or if
+``rich`` is unavailable, so callers can use it unconditionally.
+"""
+
+import logging
+import sys
+import threading
+import time
+from typing import List, Optional
+
+from .logging_config import get_logger
+
+try:
+    from rich.console import Console, Group
+    from rich.live import Live
+    from rich.rule import Rule
+    from rich.spinner import Spinner
+    from rich.table import Table
+    from rich.text import Text
+    _RICH_AVAILABLE = True
+except Exception:  # pragma: no cover - rich ships with typer, but stay safe
+    _RICH_AVAILABLE = False
+
+
+class _Frame:
+    """One document on the recursion stack and its current stage."""
+
+    __slots__ = ("name", "stage_num", "stage_total", "stage_name")
+
+    def __init__(self, name: str):
+        self.name = name
+        self.stage_num = 0
+        self.stage_total = 0
+        self.stage_name = ""
+
+
+class _LiveLogHandler(logging.Handler):
+    """Routes log records through the rich console.
+
+    While a :class:`rich.live.Live` is active on a console, printing through
+    that same console makes the text appear above the live region. This handler
+    re-uses the original console handler's level and formatter (which already
+    embeds ANSI colors via ``ColoredFormatter``); ``Text.from_ansi`` turns those
+    codes back into rich styling so colors survive.
+    """
+
+    def __init__(self, console: "Console", level: int, formatter: Optional[logging.Formatter]):
+        super().__init__(level)
+        self._console = console
+        if formatter is not None:
+            self.setFormatter(formatter)
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            msg = self.format(record)
+            self._console.print(
+                Text.from_ansi(msg), markup=False, highlight=False, soft_wrap=False
+            )
+        except Exception:
+            self.handleError(record)
+
+
+class ProgressReporter:
+    """Tracks compilation progress and renders it as a live status region."""
+
+    def __init__(self, enabled: bool = True):
+        self.enabled = bool(enabled) and _RICH_AVAILABLE
+        self._lock = threading.RLock()
+        self._stack: List[_Frame] = []
+        self._start = time.monotonic()
+        self._console: Optional["Console"] = None
+        self._live: Optional["Live"] = None
+        self._spinner = None
+        self._logger: Optional[logging.Logger] = None
+        self._saved_handlers: List[logging.Handler] = []
+        self._added_handlers: List[logging.Handler] = []
+
+    # -- context management ------------------------------------------------
+    def __enter__(self) -> "ProgressReporter":
+        if self.enabled:
+            try:
+                self._start_live()
+            except Exception:
+                # Never let a display problem break the actual compilation.
+                self.enabled = False
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        self.stop()
+        return False
+
+    def _start_live(self) -> None:
+        self._console = Console()
+        self._spinner = Spinner("dots", style="cyan")
+        self._start = time.monotonic()
+        self._logger = get_logger()
+        self._install_log_handler()
+        self._live = Live(
+            self,  # self is the renderable (see __rich__); recomputed each frame
+            console=self._console,
+            refresh_per_second=10,
+            transient=True,
+        )
+        self._live.start()
+
+    def stop(self) -> None:
+        if not self.enabled:
+            return
+        if self._live is not None:
+            try:
+                self._live.stop()
+            except Exception:
+                pass
+            self._live = None
+        self._restore_log_handler()
+        self.enabled = False
+
+    # -- logging integration ----------------------------------------------
+    def _install_log_handler(self) -> None:
+        """Replace the stdout stream handler with one that prints via rich."""
+        for handler in list(self._logger.handlers):
+            if isinstance(handler, logging.StreamHandler) and getattr(handler, "stream", None) is sys.stdout:
+                self._saved_handlers.append(handler)
+                self._logger.removeHandler(handler)
+                replacement = _LiveLogHandler(self._console, handler.level, handler.formatter)
+                self._added_handlers.append(replacement)
+                self._logger.addHandler(replacement)
+
+    def _restore_log_handler(self) -> None:
+        if self._logger is None:
+            return
+        for handler in self._added_handlers:
+            self._logger.removeHandler(handler)
+        for handler in self._saved_handlers:
+            self._logger.addHandler(handler)
+        self._added_handlers.clear()
+        self._saved_handlers.clear()
+
+    # -- progress updates --------------------------------------------------
+    def enter_document(self, name: str) -> None:
+        """Push a document onto the recursion breadcrumb."""
+        if not self.enabled:
+            return
+        with self._lock:
+            self._stack.append(_Frame(name))
+
+    def exit_document(self) -> None:
+        """Pop the current document off the breadcrumb."""
+        if not self.enabled:
+            return
+        with self._lock:
+            if self._stack:
+                self._stack.pop()
+
+    def set_stage(self, num: int, total: int, name: str) -> None:
+        """Update the stage of the current (deepest) document."""
+        if not self.enabled:
+            return
+        with self._lock:
+            if self._stack:
+                frame = self._stack[-1]
+                frame.stage_num = num
+                frame.stage_total = total
+                frame.stage_name = name
+
+    # -- rendering ---------------------------------------------------------
+    def _format_elapsed(self) -> str:
+        secs = int(time.monotonic() - self._start)
+        return f"{secs // 60:02d}:{secs % 60:02d}"
+
+    def __rich__(self):
+        # Called by Live on every refresh, so elapsed time and the spinner stay
+        # live even while the main thread is blocked in a long operation.
+        with self._lock:
+            if not self._stack:
+                grid = Table.grid(padding=(0, 1))
+                grid.add_row(self._spinner, Text("Starting...", style="dim"))
+                return Group(Rule(style="dim"), grid)
+
+            top = self._stack[-1]
+            breadcrumb = Text(" ▸ ".join(f.name for f in self._stack), style="bold cyan")
+            depth = len(self._stack) - 1
+            if depth > 0:
+                breadcrumb.append(f"   (depth {depth})", style="dim")
+
+            stage = Text("   ")
+            if top.stage_total:
+                stage.append(f"Stage {top.stage_num}/{top.stage_total}", style="green")
+                stage.append(f" · {top.stage_name}", style="white")
+            stage.append(f"    {self._format_elapsed()}", style="dim")
+
+        grid = Table.grid(padding=(0, 1))
+        grid.add_row(self._spinner, breadcrumb)
+        return Group(Rule(style="dim"), grid, stage)


### PR DESCRIPTION
## Overview

Two related improvements to the compiler: a substantial speedup of the PDF assembly pipeline, and a live terminal progress indicator. Verified end-to-end on a real 895-page nested report (`05A Structural Design`).

## 1. Single in-memory PDF edit session (perf)

Previously the base PDF was fully read or re-serialized **four times** and two intermediate PDFs (`with_overlays`, `merged`) were written to disk, with `garbage=4, deflate, clean` recompression done **twice in a row** on a 274 MB document.

Now the base PDF is opened **once** and the same `fitz.Document` is threaded through analysis → overlay → merge → marker-removal, then saved **once**.

- `ContentAnalyzer.analyze()` takes the open document and locates all markers in a single page sweep that short-circuits once they're found — replacing two opens + an O(markers × pages) per-marker scan and a separate full-text TOC sweep whose result nothing consumed (dead `toc_pages` plumbing removed).
- `OverlayProcessor` / `MergeProcessor` / `MarkerRemover` operate in place on the shared document and no longer open/save PDFs. Overlay source docs are kept open until after the final save (`show_pdf_page` may reference them) and released via `OverlayProcessor.close_sources()`.
- Reuse the `python-docx` Document parsed during placeholder detection (no second parse) and save over the temp copy directly (no extra modified-with-markers file + move).
- Share one `WordConverter` across recursive compiles, memoize `is_available()` (it dispatches a COM instance), and drop the unconditional 1 s sleep after the synchronous `Fields.Update()`.

**Result:** end-to-end ~396 s → ~291 s (~27% faster) on the large nested report. Identical output: 895 pages, 1115 TOC entries, marker-free; all sampled pages pixel-identical except a timestamp baked into a temp-filename header field (run-to-run nondeterminism present in the baseline too).

## 2. Live progress indicator (feature)

A status region pinned to the bottom of the terminal that coexists with the existing scrolling logs:

```
⠏ 05A Structural Design ▸ Steel Connection Calc   (depth 1)
   Stage 11/12 · PDF Merging    01:32
```

- Spinner + elapsed refresh on a background thread, so they keep moving even while the main thread is blocked in a Word COM call or the final save.
- Recursion breadcrumb + depth, and current pipeline stage (x/12). There is no honest single percentage (recursion breadth and the two big time sinks are only known/measurable mid-run), so stage + breadcrumb is the truthful signal.
- Built on `rich` (already shipped transitively via `typer`; now an explicit dependency). Log records are re-routed through the rich console so they render above the live region instead of corrupting it; the stdout handler and `--log-file` output are untouched and restored on exit.
- Enabled by default on a TTY, auto-disabled when piped/redirected, opt-out via `--no-progress`, no-op if `rich` is unavailable.

`ReportCompiler` now drives stages from a single stage table in `_execute_pipeline` (one source of truth for the 12-stage count, kept in lock-step with the per-stage log headers).

## Reviewer notes

- `DEVELOPER_GUIDE.md` updated to reflect the new single-document stage signatures.
- Correctness validation (page/TOC counts, marker removal, per-page text + pixmap comparison vs. a pre-change baseline) was done manually against the two large source documents; this repo has no automated test suite.
- Out of scope but noticed: the run-to-run timestamp baked into a temp-filename header field, and `~temp_..._modified_report` docx files Word keeps locked at cleanup time.