### PR TITLE
Add persistent caching and temp directory management for compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,36 @@ report-compiler compile input.docx output.pdf --keep-temp
 report-compiler compile input.docx output.pdf --verbose
 ```
 
+> The output path is normalized to end in `.pdf` automatically, so
+> `report-compiler compile input.docx output` writes `output.pdf`.
+
+#### Temporary Files and Caching
+
+Temporary working files are written to the operating system's temp folder
+(not next to your document). This avoids OneDrive/SharePoint sync locks and
+"Files On‑Demand" placeholder issues that can otherwise cause intermittent
+conversion failures.
+
+Compiled sub-document inserts (recursively compiled `.docx` appendices) are
+cached, so re-running a report — for example after a late-stage failure —
+reuses appendices that already compiled instead of re-converting every one
+through Word. Cache entries are invalidated automatically when a source
+document or any file it references changes.
+
+```bash
+# Use a custom temp directory (overrides the OS temp folder)
+report-compiler compile input.docx output.pdf --temp-dir D:\rc-temp
+
+# Use a custom cache directory
+report-compiler compile input.docx output.pdf --cache-dir D:\rc-cache
+
+# Disable the compiled-document cache for this run
+report-compiler compile input.docx output.pdf --no-cache
+```
+
+Both locations can also be set via the `REPORT_COMPILER_TEMP_DIR` and
+`REPORT_COMPILER_CACHE_DIR` environment variables.
+
 #### PDF to SVG Conversion
 
 ```bash

--- a/src/report_compiler/cli.py
+++ b/src/report_compiler/cli.py
@@ -62,6 +62,9 @@ def compile_docx(
     verbose: bool = typer.Option(False, "-v", "--verbose", "--debug", help="Enable verbose logging (DEBUG level)"),
     log_file: str = typer.Option(None, help="Log to file in addition to console"),
     no_progress: bool = typer.Option(False, "--no-progress", help="Disable the live progress indicator"),
+    temp_dir: str = typer.Option(None, "--temp-dir", help="Directory for temporary files (default: OS temp folder). Avoids OneDrive/SharePoint sync issues."),
+    cache_dir: str = typer.Option(None, "--cache-dir", help="Directory for the compiled-document cache (default: under OS temp folder)."),
+    no_cache: bool = typer.Option(False, "--no-cache", help="Disable reusing/storing compiled sub-document PDFs across runs."),
     version: bool = typer.Option(False, "--version", callback=version_callback, is_eager=True, help="Show version and exit")
 ):
     """Compile DOCX to PDF."""
@@ -70,7 +73,11 @@ def compile_docx(
     logger.info("=" * 60)
     logger.info(f"Report Compiler v{__version__} - Starting compilation")
     logger.info("=" * 60)
-    return handle_compilation(input_file, output_file, keep_temp, logger, show_progress=not no_progress)
+    return handle_compilation(
+        input_file, output_file, keep_temp, logger,
+        show_progress=not no_progress,
+        temp_dir=temp_dir, cache_dir=cache_dir, use_cache=not no_cache,
+    )
 
 @app.command("svg-import")
 def svg_import(
@@ -351,7 +358,8 @@ def handle_svg_import(input_file, output_file, page, logger) -> int:
             logger.error("=" * 60)
             return 1
 
-def handle_compilation(input_file, output_file, keep_temp, logger, show_progress: bool = True) -> int:
+def handle_compilation(input_file, output_file, keep_temp, logger, show_progress: bool = True,
+                       temp_dir: str = None, cache_dir: str = None, use_cache: bool = True) -> int:
     """Handle the traditional DOCX compilation."""
     logger.info("Mode: DOCX compilation")
     
@@ -399,7 +407,10 @@ def handle_compilation(input_file, output_file, keep_temp, logger, show_progress
                 input_path=str(input_path.absolute()),
                 output_path=str(output_path.absolute()),
                 keep_temp=keep_temp,
-                progress=progress
+                progress=progress,
+                temp_dir=temp_dir,
+                cache_dir=cache_dir,
+                use_cache=use_cache,
             )
 
             success = compiler.run()

--- a/src/report_compiler/cli.py
+++ b/src/report_compiler/cli.py
@@ -366,9 +366,20 @@ def handle_compilation(input_file, output_file, keep_temp, logger, show_progress
         return 1
     
     logger.info(f"Input DOCX: {input_path.absolute()}")
-    
+
     # Validate output directory
     output_path = Path(output_file)
+    # Ensure the output ends in .pdf. Word/LibreOffice always write a PDF and,
+    # when given a name without an extension, Word silently appends ".pdf" to the
+    # file on disk while the pipeline keeps tracking the extension-less name. That
+    # mismatch surfaces later as a confusing "no such file" when the base PDF is
+    # re-opened, so normalize it up front (mirrors the .svg check in svg-import).
+    if output_path.suffix.lower() != ".pdf":
+        normalized = output_path.parent / (output_path.name + ".pdf")
+        logger.warning(
+            f"Output path '{output_path.name}' has no .pdf extension; using '{normalized.name}' instead."
+        )
+        output_path = normalized
     try:
         output_path.parent.mkdir(parents=True, exist_ok=True)
         logger.info(f"Output PDF: {output_path.absolute()}")

--- a/src/report_compiler/core/compiler.py
+++ b/src/report_compiler/core/compiler.py
@@ -170,6 +170,15 @@ class ReportCompiler:
         # Use a more specific name for the base PDF to avoid collisions in recursion
         base_pdf_suffix = f"base_{self.recursion_level}"
         self.temp_pdf_path = self.file_manager.generate_temp_path(self.output_path, base_pdf_suffix)
+        # The base temp file is always a PDF. If the caller's output path lacked a
+        # ".pdf" extension the generated temp path would too, but the converter
+        # (Word's ExportAsFixedFormat in particular) writes an actual ".pdf" file,
+        # so a later fitz.open() on the extension-less path fails. Guarantee the
+        # ".pdf" suffix here and keep the cleanup list in sync with the real name.
+        if not self.temp_pdf_path.lower().endswith(".pdf"):
+            self.temp_pdf_path = self.file_manager.retarget_temp_path(
+                self.temp_pdf_path, self.temp_pdf_path + ".pdf"
+            )
         self.final_pdf_path = self.output_path
         self.logger.debug(f"{self._log_prefix()}  > Input DOCX: {self.input_path}")
         self.logger.debug(f"{self._log_prefix()}  > Output PDF: {self.final_pdf_path}")

--- a/src/report_compiler/core/compiler.py
+++ b/src/report_compiler/core/compiler.py
@@ -7,11 +7,14 @@ report compilation process, from input validation through PDF generation.
 
 import logging
 import os
+import time
 from typing import Set
 
 import fitz  # PyMuPDF
 
+from .config import Config
 from ..utils.file_manager import FileManager
+from ..utils.compile_cache import CompileCache
 from ..utils.validators import Validators
 from ..document.placeholder_parser import PlaceholderParser
 from ..pdf.content_analyzer import ContentAnalyzer
@@ -28,7 +31,7 @@ from ..utils.progress import ProgressReporter
 class ReportCompiler:
     """Main orchestrator class for report compilation."""
     
-    def __init__(self, input_path: str, output_path: str, keep_temp: bool = False, recursion_level: int = 0, file_manager: FileManager = None, word_converter: WordConverter = None, progress: ProgressReporter = None):
+    def __init__(self, input_path: str, output_path: str, keep_temp: bool = False, recursion_level: int = 0, file_manager: FileManager = None, word_converter: WordConverter = None, progress: ProgressReporter = None, temp_dir: str = None, cache_dir: str = None, use_cache: bool = True, compile_cache: CompileCache = None):
         """
         Initialize the report compiler.
 
@@ -42,6 +45,15 @@ class ReportCompiler:
                 compiles, so a single Word/COM instance serves the whole run.
             progress: Shared progress reporter for the live status indicator.
                 Defaults to a disabled (no-op) reporter when not supplied.
+            temp_dir: Override for the base directory of temporary files. When not
+                set, a per-run directory under the OS temp folder is used (see
+                Config.get_temp_base_dir). Only consulted for the top-level call.
+            cache_dir: Override for the compiled-document cache directory. Only
+                consulted for the top-level call.
+            use_cache: Whether to reuse/store compiled sub-document PDFs across
+                runs. Only consulted for the top-level call.
+            compile_cache: An existing cache instance shared across recursive
+                compiles. Created automatically for the top-level call.
         """
         self.input_path = os.path.abspath(input_path)
         self.output_path = os.path.abspath(output_path)
@@ -49,8 +61,21 @@ class ReportCompiler:
         self.recursion_level = recursion_level
         self.logger = get_compiler_logger()
 
-        # Initialize components
-        self.file_manager = file_manager if file_manager else FileManager(keep_temp)
+        # Initialize components. The top-level call owns the shared file manager
+        # (with a per-run work directory under the OS temp folder) and the
+        # compiled-document cache; recursive calls reuse the instances passed in.
+        if file_manager is not None:
+            self.file_manager = file_manager
+        else:
+            run_dir = os.path.join(
+                Config.get_temp_base_dir(temp_dir),
+                f"{Config.RUN_DIR_PREFIX}{int(time.time() * 1000)}_{os.getpid()}",
+            )
+            self.file_manager = FileManager(keep_temp, work_dir=run_dir)
+        if compile_cache is not None:
+            self.compile_cache = compile_cache
+        else:
+            self.compile_cache = CompileCache(Config.get_cache_dir(cache_dir), enabled=use_cache)
         self.validators = Validators()
         self.placeholder_parser = PlaceholderParser()
         self.content_analyzer = ContentAnalyzer()
@@ -289,14 +314,28 @@ class ReportCompiler:
         for placeholder in docx_inserts:
             # The path from the parser is relative to the document, so make it absolute.
             docx_path = os.path.abspath(os.path.join(self.base_directory, placeholder['file_path']))
-            
+
             self.logger.info(f"{self._log_prefix()}  > Resolving insert: {os.path.basename(docx_path)}")
 
-            # Generate a unique temp PDF path for the compiled DOCX.
-            # The extension must be .pdf for the rest of the process.
+            # Reuse a previously compiled PDF for this exact source (and its
+            # dependencies) if one is cached. This lets a re-run skip the
+            # expensive Word conversion for appendices that already compiled.
+            cache_key = self.compile_cache.compute_key(docx_path)
+            cached_pdf = self.compile_cache.get(cache_key)
+            if cached_pdf:
+                self.logger.info(f"{self._log_prefix()}  > ✓ Reusing cached compilation for {os.path.basename(docx_path)}")
+                placeholder['file_path'] = cached_pdf
+                placeholder['is_recursive_docx'] = False
+                placeholder['original_path'] = docx_path
+                continue
+
+            # Generate a unique temp PDF path for the compiled DOCX. Build it from
+            # a .pdf base name so the path tracked for cleanup matches the file
+            # that is actually written (the rest of the process needs a .pdf).
+            pdf_base = os.path.splitext(docx_path)[0] + ".pdf"
             temp_output_pdf = self.file_manager.generate_temp_path(
-                docx_path, f"recursive_{self.recursion_level}"
-            ).replace(".docx", ".pdf")
+                pdf_base, f"recursive_{self.recursion_level}"
+            )
 
             # Create and run a sub-compiler.
             sub_compiler = ReportCompiler(
@@ -306,12 +345,16 @@ class ReportCompiler:
                 recursion_level=self.recursion_level + 1,
                 file_manager=self.file_manager,
                 word_converter=self.word_converter,
-                progress=self.progress
+                progress=self.progress,
+                compile_cache=self.compile_cache
             )
 
             if not sub_compiler.run(processed_files):
                 self.logger.error(f"{self._log_prefix()}  > ❌ Failed to compile recursive DOCX: {docx_path}")
                 return False
+
+            # Store the freshly compiled PDF in the cache for future runs.
+            self.compile_cache.put(cache_key, temp_output_pdf)
 
             # Update placeholder to point to the new PDF. The path must be absolute.
             self.logger.info(f"{self._log_prefix()}  > ✓ Successfully compiled {os.path.basename(docx_path)} to {os.path.basename(temp_output_pdf)}")

--- a/src/report_compiler/core/config.py
+++ b/src/report_compiler/core/config.py
@@ -2,7 +2,9 @@
 Configuration and constants for the report compiler.
 """
 
+import os
 import re
+import tempfile
 from typing import Optional
 
 
@@ -25,6 +27,23 @@ class Config:
     
     # File handling
     TEMP_FILE_PREFIX = "~temp_"
+
+    # Temporary working files are kept in the OS temp directory by default rather
+    # than alongside the source document. Storing them next to the working files
+    # is problematic on cloud-synced folders (OneDrive/SharePoint), where sync
+    # locks and Files-On-Demand placeholders cause intermittent locking and
+    # "file not found" errors during conversion. Both locations can be overridden
+    # via CLI flags or these environment variables.
+    TEMP_DIR_ENV = "REPORT_COMPILER_TEMP_DIR"
+    CACHE_DIR_ENV = "REPORT_COMPILER_CACHE_DIR"
+    # Sub-directory name used under the temp base for a single compile run.
+    RUN_DIR_PREFIX = "report_compiler_run_"
+    # Persistent cache of compiled sub-document PDFs, so a re-run (e.g. after a
+    # late-stage failure) can reuse appendices that already compiled instead of
+    # re-invoking Word on each one.
+    CACHE_SUBDIR = "report_compiler_cache"
+    # Cached artifacts untouched for longer than this are pruned on startup.
+    CACHE_TTL_DAYS = 7
     SUPPORTED_PDF_EXTENSIONS = ['.pdf']
     SUPPORTED_DOCX_EXTENSIONS = ['.docx']
     SUPPORTED_IMAGE_EXTENSIONS = ['.png', '.jpg', '.jpeg', '.gif', '.bmp', '.tiff', '.webp', '.heic', '.heif' , '.emf', '.wmf']
@@ -73,3 +92,25 @@ class Config:
     def get_temp_filename(cls, base_name: str, timestamp: int) -> str:
         """Generate temporary filename."""
         return f"{cls.TEMP_FILE_PREFIX}{base_name}_{timestamp}"
+
+    @classmethod
+    def get_temp_base_dir(cls, override: Optional[str] = None) -> str:
+        """Resolve the base directory for per-run temporary files.
+
+        Precedence: explicit override (CLI flag) > environment variable >
+        OS temp directory.
+        """
+        return override or os.environ.get(cls.TEMP_DIR_ENV) or tempfile.gettempdir()
+
+    @classmethod
+    def get_cache_dir(cls, override: Optional[str] = None) -> str:
+        """Resolve the directory for the persistent compiled-document cache.
+
+        Precedence: explicit override (CLI flag) > environment variable >
+        a stable sub-directory of the OS temp directory.
+        """
+        return (
+            override
+            or os.environ.get(cls.CACHE_DIR_ENV)
+            or os.path.join(tempfile.gettempdir(), cls.CACHE_SUBDIR)
+        )

--- a/src/report_compiler/utils/compile_cache.py
+++ b/src/report_compiler/utils/compile_cache.py
@@ -1,0 +1,187 @@
+"""
+Persistent cache of compiled sub-document PDFs.
+
+Compiling a nested DOCX insert is the most expensive step in a run: each one
+invokes Microsoft Word (or LibreOffice) to render a PDF. When a large report
+fails late in the pipeline, re-running it would normally re-compile every
+appendix from scratch. This cache stores each compiled sub-document PDF keyed
+on a content signature of its source (and that source's dependencies), so a
+re-run reuses unchanged appendices instead of rebuilding them.
+
+The cache is intentionally conservative: any condition that prevents computing a
+reliable signature (unreadable file, parse error) yields a volatile key, so a
+stale PDF is never served in place of changed content.
+"""
+
+import os
+import shutil
+import time
+import hashlib
+from typing import Optional
+
+from ..core.config import Config
+from .logging_config import get_file_logger
+
+
+class CompileCache:
+    """Content-addressed cache for compiled sub-document PDFs."""
+
+    _READ_CHUNK = 1024 * 1024  # 1 MiB
+
+    def __init__(self, cache_dir: str, enabled: bool = True):
+        self.enabled = enabled
+        self.cache_dir = cache_dir
+        self.logger = get_file_logger()
+        # Lazily imported to avoid a document<->utils import cycle.
+        self._parser = None
+        if self.enabled:
+            try:
+                os.makedirs(self.cache_dir, exist_ok=True)
+                self._prune()
+            except OSError as e:
+                self.logger.warning(
+                    "Could not initialise compile cache at %s (%s); caching disabled.",
+                    self.cache_dir, e,
+                )
+                self.enabled = False
+
+    # -- public API ---------------------------------------------------------
+
+    def compute_key(self, docx_path: str) -> Optional[str]:
+        """Compute a stable cache key for a source DOCX and its dependencies.
+
+        Returns None if caching is disabled. The key changes whenever the source
+        document, or any file it references (transitively, for nested DOCX
+        inserts), changes.
+        """
+        if not self.enabled:
+            return None
+        return self._signature(docx_path, set())
+
+    def get(self, key: Optional[str]) -> Optional[str]:
+        """Return the path to a cached PDF for ``key``, or None on a miss."""
+        if not self.enabled or not key:
+            return None
+        path = self._path_for(key)
+        if os.path.exists(path):
+            # Touch so frequently reused entries survive TTL pruning.
+            try:
+                os.utime(path, None)
+            except OSError:
+                pass
+            return path
+        return None
+
+    def put(self, key: Optional[str], pdf_path: str) -> Optional[str]:
+        """Copy a freshly compiled PDF into the cache and return its cached path.
+
+        Writes to a temporary name and atomically renames so a concurrent run
+        never observes a half-written cache entry. Failures are non-fatal.
+        """
+        if not self.enabled or not key:
+            return None
+        if not os.path.exists(pdf_path):
+            return None
+        dest = self._path_for(key)
+        tmp = f"{dest}.{os.getpid()}.{int(time.time() * 1000)}.tmp"
+        try:
+            shutil.copy2(pdf_path, tmp)
+            os.replace(tmp, dest)
+            return dest
+        except OSError as e:
+            self.logger.warning("Could not write cache entry for %s (%s).",
+                                os.path.basename(pdf_path), e)
+            if os.path.exists(tmp):
+                try:
+                    os.remove(tmp)
+                except OSError:
+                    pass
+            return None
+
+    # -- internals ----------------------------------------------------------
+
+    def _path_for(self, key: str) -> str:
+        return os.path.join(self.cache_dir, f"{key}.pdf")
+
+    def _get_parser(self):
+        if self._parser is None:
+            from ..document.placeholder_parser import PlaceholderParser
+            self._parser = PlaceholderParser()
+        return self._parser
+
+    def _hash_file(self, path: str, hasher) -> None:
+        with open(path, "rb") as f:
+            for chunk in iter(lambda: f.read(self._READ_CHUNK), b""):
+                hasher.update(chunk)
+
+    def _signature(self, docx_path: str, seen: set) -> str:
+        """Recursively hash a DOCX and the files it references.
+
+        The document's own bytes capture its text (and therefore every
+        placeholder's parameters, e.g. page ranges). Referenced files are folded
+        in by content (nested DOCX) or by size+mtime (PDFs/images), so a changed
+        dependency invalidates the parent even when the parent text is untouched.
+        """
+        docx_path = os.path.abspath(docx_path)
+        hasher = hashlib.sha256()
+
+        if docx_path in seen:
+            # Cycle guard: contribute a stable marker and stop recursing.
+            hasher.update(b"<cycle>")
+            return hasher.hexdigest()
+        seen.add(docx_path)
+
+        try:
+            self._hash_file(docx_path, hasher)
+        except OSError:
+            # Cannot read the source -> never serve a cached hit for it.
+            return self._volatile_key()
+
+        base_dir = os.path.dirname(docx_path)
+        try:
+            placeholders = self._get_parser().find_all_placeholders(docx_path)
+        except Exception:
+            return self._volatile_key()
+
+        deps = placeholders.get("table", []) + placeholders.get("paragraph", [])
+        parts = []
+        for p in deps:
+            file_path = p.get("file_path")
+            if not file_path:
+                continue
+            dep_abs = os.path.abspath(os.path.join(base_dir, file_path))
+            if dep_abs.lower().endswith(".docx") and os.path.exists(dep_abs):
+                parts.append(self._signature(dep_abs, seen))
+            else:
+                try:
+                    st = os.stat(dep_abs)
+                    parts.append(f"{dep_abs}:{st.st_size}:{st.st_mtime_ns}")
+                except OSError:
+                    parts.append(f"{dep_abs}:missing")
+
+        for part in sorted(parts):
+            hasher.update(part.encode("utf-8", "ignore"))
+        return hasher.hexdigest()
+
+    @staticmethod
+    def _volatile_key() -> str:
+        """A never-repeating key, guaranteeing a cache miss."""
+        return "volatile-" + os.urandom(16).hex()
+
+    def _prune(self) -> None:
+        """Delete cache entries not accessed within the configured TTL."""
+        ttl_seconds = Config.CACHE_TTL_DAYS * 24 * 3600
+        cutoff = time.time() - ttl_seconds
+        try:
+            entries = os.listdir(self.cache_dir)
+        except OSError:
+            return
+        for name in entries:
+            if not name.endswith(".pdf"):
+                continue
+            path = os.path.join(self.cache_dir, name)
+            try:
+                if os.path.getmtime(path) < cutoff:
+                    os.remove(path)
+            except OSError:
+                pass

--- a/src/report_compiler/utils/file_manager.py
+++ b/src/report_compiler/utils/file_manager.py
@@ -44,6 +44,29 @@ class FileManager:
         self.temp_files.append(temp_path)
         return temp_path
     
+    def retarget_temp_path(self, old_path: str, new_path: str) -> str:
+        """
+        Replace a previously generated temp path with a corrected one.
+
+        Keeps the cleanup tracking list consistent when a caller needs to adjust a
+        path returned by ``generate_temp_path`` (for example to force a ``.pdf``
+        extension) so the file that is actually written still gets cleaned up.
+
+        Args:
+            old_path: The path previously returned by ``generate_temp_path``.
+            new_path: The corrected path to track instead.
+
+        Returns:
+            The new path.
+        """
+        try:
+            index = self.temp_files.index(old_path)
+            self.temp_files[index] = new_path
+        except ValueError:
+            # Not tracked (e.g. caller passed an untracked path); just track the new one.
+            self.temp_files.append(new_path)
+        return new_path
+
     def create_temp_copy(self, source_path: str, suffix: str = "") -> str:
         """
         Create a temporary copy of a file.

--- a/src/report_compiler/utils/file_manager.py
+++ b/src/report_compiler/utils/file_manager.py
@@ -2,6 +2,7 @@
 File management utilities for temporary files and cleanup.
 """
 
+import hashlib
 import os
 import time
 from pathlib import Path
@@ -12,34 +13,66 @@ from .logging_config import get_file_logger
 
 class FileManager:
     """Manages temporary files and cleanup operations."""
-    
-    def __init__(self, keep_temp: bool = False):
+
+    def __init__(self, keep_temp: bool = False, work_dir: Optional[str] = None):
+        """
+        Args:
+            keep_temp: Whether to keep temporary files for debugging.
+            work_dir: Directory in which to place temporary files. When provided,
+                all temp files are created here (instead of alongside the source
+                document), which keeps cloud-synced source folders free of churn
+                and avoids OneDrive sync/lock issues. The directory is created if
+                needed and removed on cleanup if empty.
+        """
         self.keep_temp = keep_temp
         self.temp_files: List[str] = []
         self.timestamp = int(time.time() * 1000)  # Millisecond timestamp
         self.logger = get_file_logger()
-        self.logger = get_file_logger()
-    
+        self.work_dir = work_dir
+        if self.work_dir:
+            try:
+                os.makedirs(self.work_dir, exist_ok=True)
+            except OSError as e:
+                # Fall back to source-adjacent temp files rather than failing the run.
+                self.logger.warning(
+                    "Could not create temp work directory %s (%s); "
+                    "falling back to source-adjacent temp files.",
+                    self.work_dir, e,
+                )
+                self.work_dir = None
+
     def generate_temp_path(self, base_path: str, suffix: str = "") -> str:
         """
         Generate a temporary file path based on the base path.
-        
+
         Args:
             base_path: Original file path
             suffix: Additional suffix for the temp file
-            
+
         Returns:
             Path to temporary file
         """
-        base_dir = os.path.dirname(base_path)
         base_name = os.path.splitext(os.path.basename(base_path))[0]
         ext = os.path.splitext(base_path)[1]
-        
-        if suffix:
-            temp_name = f"{Config.TEMP_FILE_PREFIX}{base_name}_{suffix}_{self.timestamp}{ext}"
+
+        if self.work_dir:
+            base_dir = self.work_dir
+            # When several source files from different directories share a base
+            # name, a single flat work directory would collide. Disambiguate with
+            # a short hash of the source's directory so the temp names stay unique.
+            digest = hashlib.sha1(
+                os.path.dirname(os.path.abspath(base_path)).encode("utf-8", "ignore")
+            ).hexdigest()[:8]
+            name_core = f"{base_name}_{digest}"
         else:
-            temp_name = f"{Config.TEMP_FILE_PREFIX}{base_name}_{self.timestamp}{ext}"
-        
+            base_dir = os.path.dirname(base_path)
+            name_core = base_name
+
+        if suffix:
+            temp_name = f"{Config.TEMP_FILE_PREFIX}{name_core}_{suffix}_{self.timestamp}{ext}"
+        else:
+            temp_name = f"{Config.TEMP_FILE_PREFIX}{name_core}_{self.timestamp}{ext}"
+
         temp_path = os.path.join(base_dir, temp_name)
         self.temp_files.append(temp_path)
         return temp_path
@@ -106,8 +139,16 @@ class FileManager:
         
         if removed_count == 0 and len(self.temp_files) > 0:
             self.logger.info("  • No temporary files to clean up")
-        
+
         self.temp_files.clear()
+
+        # Remove the per-run work directory if we created one and it is now empty.
+        if self.work_dir and os.path.isdir(self.work_dir):
+            try:
+                os.rmdir(self.work_dir)
+            except OSError:
+                # Not empty (e.g. unexpected leftovers) or in use; leave it in place.
+                pass
     
     def __enter__(self):
         """Context manager entry."""


### PR DESCRIPTION
## Summary

This PR introduces two major improvements to the report compilation pipeline:

1. **Persistent caching of compiled sub-documents**: A content-addressed cache stores compiled sub-document PDFs (nested DOCX inserts) keyed on a signature of their source and dependencies. This allows re-runs to reuse unchanged appendices instead of re-compiling them through Word, significantly improving performance when large reports fail late in the pipeline.

2. **Configurable temporary file management**: Temporary files are now written to the OS temp directory by default (instead of alongside source documents), with support for custom temp and cache directories via CLI flags or environment variables. This avoids OneDrive/SharePoint sync locks and "Files On-Demand" placeholder issues that cause intermittent conversion failures.

## Key Changes

- **New `CompileCache` class** (`src/report_compiler/utils/compile_cache.py`):
  - Content-addressed cache for compiled sub-document PDFs
  - Recursively hashes DOCX files and their dependencies (nested DOCX inserts, PDFs, images)
  - Handles cycles in document references
  - Conservative approach: any condition preventing reliable signature computation yields a volatile key to avoid serving stale PDFs
  - Automatic TTL-based pruning of old entries (configurable via `CACHE_TTL_DAYS`)

- **Enhanced `FileManager` class**:
  - Added `work_dir` parameter to support centralized temp file storage
  - Implements directory disambiguation using content hashes when multiple source files share the same base name
  - New `retarget_temp_path()` method to correct paths after generation (e.g., forcing `.pdf` extension)
  - Automatic cleanup of empty per-run work directories

- **Updated `ReportCompiler` class**:
  - Accepts `temp_dir`, `cache_dir`, `use_cache`, and `compile_cache` parameters
  - Creates per-run temp directories under OS temp folder for top-level calls
  - Checks cache before compiling nested DOCX inserts; stores freshly compiled PDFs in cache
  - Ensures base PDF path always has `.pdf` extension to match actual file written by Word/LibreOffice

- **Extended `Config` class**:
  - New methods: `get_temp_base_dir()` and `get_cache_dir()` with precedence: CLI override > environment variable > default
  - New constants: `TEMP_DIR_ENV`, `CACHE_DIR_ENV`, `RUN_DIR_PREFIX`, `CACHE_SUBDIR`, `CACHE_TTL_DAYS`

- **CLI enhancements** (`src/report_compiler/cli.py`):
  - New flags: `--temp-dir`, `--cache-dir`, `--no-cache`
  - Output path normalization: automatically appends `.pdf` extension if missing
  - Updated help text and README with usage examples

## Notable Implementation Details

- **Cache key computation**: Recursively hashes document content and dependency metadata (size/mtime for non-DOCX files, full content hash for nested DOCX). Cycle detection prevents infinite recursion.
- **Atomic cache writes**: Uses temporary files with PID/timestamp and atomic rename to prevent concurrent runs from observing half-written entries.
- **Graceful degradation**: Cache initialization failures disable caching but don't fail the compilation; temp directory creation failures fall back to source-adjacent temp files.
- **Access tracking**: Cache entries are touched on retrieval to survive TTL pruning, ensuring frequently reused appendices remain available.

https://claude.ai/code/session_01GeQocUQzD4jDR9xP87XLCC