### PR TITLE
In-document overlay preview (Tags / Quick / Full)

### DIFF
--- a/docs/superpowers/specs/2026-06-24-in-document-overlay-preview-design.md
+++ b/docs/superpowers/specs/2026-06-24-in-document-overlay-preview-design.md
@@ -1,0 +1,78 @@
+# In-Document Overlay Preview — Design
+
+## Context
+
+**Problem:** An OVERLAY placeholder is an empty 1×1 table cell holding a `[[OVERLAY: file.pdf, page=…]]` tag until compile. Coworkers can't tell *which* pages an overlay will insert or *how* they'll look, and can't see how the rest of the document reflows around multi-page overlays.
+
+**Goal:** Let users flip the whole document between **Tags**, a lightweight **Quick preview**, and a reflow-accurate **Full preview** of every overlay — rendered from the real PDFs, crop-accurate — without ever endangering a full-resolution compile.
+
+This is feature #3 of the GUI roadmap. It builds on the existing foundation: the COM server, `gui/pdf_render` (PyMuPDF raster), `content_analyzer` (cropping), `placeholder_parser`/`Config` (OVERLAY regex), and the Python-drives-Word pattern.
+
+**Decisions locked in:**
+- Document-wide **ribbon dropdown**: Tags / Quick / Full.
+- **Quick** = first selected page + `+N` badge (cell stays 1×1). **Full** = expand into per-page rows so surrounding content reflows.
+- Previews are **crop-accurate** (reuse `content_analyzer`).
+- **Recovery is a property of the compiler**, not just the toggle (see below).
+- Safeguards: redundant tag stored in each preview image's AltText; a **Repair overlays** command. (No strip-on-save, no save-blocking.)
+
+## Recovery & fidelity (the core guarantee)
+
+Preview images are **low-res throwaways**; the compiler ignores them entirely — it reads the tag, resolves the original PDF, and renders it vector-accurate via `show_pdf_page`. So previews can never reduce output quality; they only bloat the file while shown.
+
+The `[[OVERLAY: …]]` tag is always preserved as **hidden text** in the cell (survives save/reopen; still present in `cell.text`), and **redundantly** in each preview image's AltText. Canonical state of an overlay is a **1×1 single-cell borderless table** whose cell text matches the OVERLAY regex.
+
+**Compile-pipeline normalization (mandatory, covers every compile path — CLI, COM, button):** before parsing, the compiler normalizes overlays on its working copy so a saved-in-preview document always compiles correctly:
+- remove inline images marked `RCPREVIEW`,
+- collapse any expanded multi-row overlay table back to the single tagged row,
+- (hidden tag text is read fine by the parser, so no unhide needed for compile).
+
+Without this, a saved Full-preview overlay (multi-row table) would be **silently skipped** by the parser (it only treats 1×1 tables as overlays) and quick-preview images would leak into output. Normalization makes recovery guaranteed regardless of who compiles or how.
+
+## Architecture / flow
+
+```
+Ribbon dropdown "Overlay view"  (Tags | Quick | Full)   [VBA thin callback]
+  └ localDocPath = GetLocalPath(ActiveDocument.FullName)
+  └ CreateObject("ReportCompiler.Application").SetOverlayPreview(localDocPath, mode)
+
+COM server  SetOverlayPreview(doc_path, mode)
+  └ document/overlay_preview.set_overlay_view(doc_path, mode)
+       GetActiveObject("Word.Application") → restore-then-apply (idempotent):
+         1. restore_to_tags(doc): delete RCPREVIEW shapes, collapse rows to the tagged row, unhide tag
+         2. if mode == quick: per overlay → render first page → insert image + "+N" caption, hide tag
+            if mode == full:  per overlay → render each selected page → replicate rows + images, hide tag
+
+Compile (any path) → docx_processor normalizes overlays first (python-docx) → parse → render from source PDFs
+"Repair overlays" ribbon button → SetOverlayPreview(doc, "tags")  (force canonical)
+```
+
+Word stays the source of truth for the live preview; the operation runs synchronously in the COM call (typical docs have a handful of overlays). If it proves slow on large jobs, it can move to the async job+poll pattern later.
+
+## Components
+
+- **`utils/pdf_render.py`** (move from `gui/`): `page_count`, `render_page_png(pdf, page_index, target_width_px, clip=None)` — add optional `clip` rect for crop-accurate rendering. `gui/pdf_render` keeps only the `QPixmap` wrapper, importing from here (so non-GUI code no longer imports the GUI package).
+- **`document/overlay_preview.py`** (new): the live-Word engine — `set_overlay_view(doc_path, mode)`, `restore_to_tags(doc)`, `apply_quick(doc, …)`, `apply_full(doc, …)`, `iter_overlay_tables(doc)`. Uses win32com (`GetActiveObject`), the OVERLAY regex + `PageSelector` (page expansion) + `content_analyzer` (crop rect → clip). Marks inserted shapes with AltText = the tag, prefixed by the `RCPREVIEW` marker.
+- **`document/docx_processor.py`**: add `_normalize_overlay_previews(doc)` (python-docx) run at the start of processing — removes `RCPREVIEW` `<w:drawing>` runs and collapses multi-row overlay tables to the tagged row. Reuse the existing OVERLAY regex.
+- **`core/config.py`**: add `OVERLAY_PREVIEW_MARKER = "RCPREVIEW"` so the live engine and the compile normalizer agree on the marker.
+- **`com_server.py`**: `SetOverlayPreview(doc_path, mode)` added to `_public_methods_`.
+- **VBA `ReportingTools.bas` + `report_compiler_UI.xml`**: the "Overlay view" dropdown (Tags/Quick/Full) + a "Repair overlays" button; rebuild the `.dotm`. `RunReportCompiler` keeps working since normalization now lives in the pipeline (the button no longer needs its own strip, though it may still set Tags first for a clean visual).
+
+## Crop fidelity
+For each page, compute the crop rect with `content_analyzer.apply_content_cropping(page, crop_enabled)` and pass it as `clip` to `render_page_png`, so the preview matches what the compiler would overlay.
+
+## Error handling
+- Missing PDF / invalid page spec: the cell shows a red `⚠ missing: file.pdf` note but keeps the tag; the toggle continues and reports `rendered X overlays, Y errors`.
+- COM server not registered: the standard "COM Server Not Registered" message (mirrors the other buttons).
+- Restore is defensive: an overlay is any single-column table with a cell whose text matches the OVERLAY regex; the row carrying the tag is kept, others deleted.
+
+## Out of scope
+- Editing overlay parameters from preview (that's the overlay dialog / future link manager).
+- Per-overlay (non-document-wide) toggling.
+- Strip-on-save and save-blocking (explicitly declined).
+- Previews for IMAGE/INSERT placeholders (overlay-only for now).
+
+## Verification
+1. **Unit (no Word):** tag parse → (file, pages, crop); `PageSelector` expansion; `render_page_png` with a `clip` produces a valid cropped PNG; `docx_processor._normalize_overlay_previews` on a hand-built docx (multi-row table with `RCPREVIEW` images) collapses to a 1×1 with the tag intact.
+2. **Compile recovery (no live Word):** build a docx in the expanded/preview state (multi-row + marked images + hidden tag), run a normal `compile`, and confirm the overlay renders from the source PDF at full resolution and the preview images don't appear in output.
+3. **End-to-end in Word (real machine):** doc with 2 overlays → cycle Tags→Quick→Full→Tags and confirm a clean round-trip (cell text restored, no leftover rows/images); save while in Full preview, reopen, run **Repair overlays**, compile → correct high-res output.
+4. **Caveat:** the live-Word apply/restore (COM `GetActiveObject` manipulation) can't run in the agent sandbox — same registry/COM isolation as before; verified on a real interactive Windows session. The pure logic and the compile-time normalization are fully testable headless.

--- a/src/report_compiler/com_server.py
+++ b/src/report_compiler/com_server.py
@@ -167,6 +167,7 @@ class ReportCompilerCOMServer:
         "CompileAsync",
         "SvgImportAsync",
         "LaunchOverlayDialog",
+        "SetOverlayPreview",
         "GetJobStatus",
         "GetJobMessage",
     ]
@@ -222,6 +223,16 @@ class ReportCompilerCOMServer:
             close_fds=True,
         )
         return "launched"
+
+    def SetOverlayPreview(self, doc_path, mode):
+        """Switch the document's overlay view: 'tags', 'quick', or 'full'.
+
+        Runs synchronously (manipulates the live document) and returns a short summary.
+        Errors are raised to the COM client.
+        """
+        from report_compiler.document import overlay_preview
+
+        return overlay_preview.set_overlay_view(str(doc_path), str(mode))
 
     def GetJobStatus(self, job_id):
         job = _JOBS.get(str(job_id))

--- a/src/report_compiler/core/compiler.py
+++ b/src/report_compiler/core/compiler.py
@@ -215,6 +215,15 @@ class ReportCompiler:
             return False
         
         try:
+            # Collapse any in-document overlay previews (expanded rows + preview images)
+            # back to canonical tags first, so a doc saved mid-preview still compiles.
+            normalized = self.docx_processor.normalize_overlay_previews(self.temp_docx_path)
+            if normalized:
+                self.logger.info(f"{self._log_prefix()}  > Normalized {normalized} overlay preview(s) back to tags.")
+        except Exception as e:
+            self.logger.warning(f"{self._log_prefix()}  > Overlay preview normalization skipped: {e}")
+
+        try:
             self.placeholders = self.placeholder_parser.find_all_placeholders(self.temp_docx_path)
             if self.placeholders['total'] == 0:
                 self.logger.info(f"{self._log_prefix()}  > No placeholders found.")

--- a/src/report_compiler/core/config.py
+++ b/src/report_compiler/core/config.py
@@ -22,6 +22,10 @@ class Config:
     # PDF processing defaults
     DEFAULT_PADDING = 32  # points
     DEFAULT_CROP_ENABLED = False
+
+    # Marker stored in the AltText of in-document overlay-preview images so they can be
+    # found and stripped again (by the live toggle and the compile-time normalizer).
+    OVERLAY_PREVIEW_MARKER = "RCPREVIEW"
     
     # File handling
     TEMP_FILE_PREFIX = "~temp_"

--- a/src/report_compiler/document/docx_processor.py
+++ b/src/report_compiler/document/docx_processor.py
@@ -6,6 +6,7 @@ import os
 from typing import Dict, List, Optional
 from docx import Document
 from docx.shared import Inches
+from docx.oxml.ns import qn
 from PIL import Image
 from ..core.config import Config
 from ..utils.logging_config import get_docx_logger
@@ -18,6 +19,88 @@ class DocxProcessor:
 
     def __init__(self):
         self.logger = get_docx_logger()
+
+    # --- In-document overlay-preview normalization ---------------------------
+    # The in-document preview feature can leave a saved docx with overlay tables
+    # expanded into multiple rows and filled with low-res preview images. Those would
+    # break compilation (the parser only treats 1x1 tables as overlays, and the images
+    # would leak into output). This collapses every overlay table back to its canonical
+    # 1x1 tag form so any compile path recovers a clean, full-resolution result.
+
+    def normalize_overlay_previews(self, docx_path: str) -> int:
+        """Collapse in-document overlay previews back to canonical tag tables, in place.
+
+        Returns the number of overlay tables that were normalized.
+        """
+        doc = Document(docx_path)
+        count = 0
+        for table in doc.tables:
+            if not self._is_single_column(table):
+                continue
+            tag = self._overlay_tag_of_table(table)
+            if tag is None:
+                continue
+            self._remove_preview_images(table)
+            self._collapse_overlay_table(table, tag)
+            count += 1
+        if count:
+            doc.save(docx_path)
+        return count
+
+    @staticmethod
+    def _is_single_column(table) -> bool:
+        try:
+            return len(table.rows) >= 1 and all(len(row.cells) == 1 for row in table.rows)
+        except Exception:
+            return False
+
+    def _overlay_tag_of_table(self, table) -> Optional[str]:
+        """Return the overlay tag for this table, or None if it isn't an overlay.
+
+        Prefers the tag from a cell's text (hidden text still appears in .text); falls
+        back to the redundant copy stored in a preview image's AltText.
+        """
+        for row in table.rows:
+            match = Config.OVERLAY_REGEX.search(row.cells[0].text)
+            if match:
+                return match.group(0)
+        return self._tag_from_preview_image(table)
+
+    def _tag_from_preview_image(self, table) -> Optional[str]:
+        marker = Config.OVERLAY_PREVIEW_MARKER
+        for docpr in table._tbl.iter(qn("wp:docPr")):
+            descr = docpr.get("descr") or ""
+            if descr.startswith(marker):
+                tag = descr[len(marker):].lstrip(":").strip()
+                if Config.OVERLAY_REGEX.search(tag):
+                    return Config.OVERLAY_REGEX.search(tag).group(0)
+        return None
+
+    def _remove_preview_images(self, table) -> None:
+        """Delete runs holding a preview image (identified by the marker in AltText)."""
+        marker = Config.OVERLAY_PREVIEW_MARKER
+        for docpr in list(table._tbl.iter(qn("wp:docPr"))):
+            if not (docpr.get("descr") or "").startswith(marker):
+                continue
+            run = docpr
+            while run is not None and run.tag != qn("w:r"):
+                run = run.getparent()
+            if run is not None and run.getparent() is not None:
+                run.getparent().remove(run)
+
+    def _collapse_overlay_table(self, table, tag: str) -> None:
+        """Keep only the tag-bearing row and set its cell to the plain tag text."""
+        tbl = table._tbl
+        rows = table.rows
+        keep_idx = 0
+        for i, row in enumerate(rows):
+            if Config.OVERLAY_REGEX.search(row.cells[0].text):
+                keep_idx = i
+                break
+        for i, tr in enumerate(tbl.findall(qn("w:tr"))):
+            if i != keep_idx:
+                tbl.remove(tr)
+        table.rows[0].cells[0].text = tag
 
     def create_modified_docx(
         self, input_path: str, placeholders: Dict[str, List[Dict]], output_path: str

--- a/src/report_compiler/document/overlay_preview.py
+++ b/src/report_compiler/document/overlay_preview.py
@@ -56,6 +56,7 @@ def set_overlay_view(doc_path: str, mode: str) -> str:
         _restore_table(table)
 
     if mode == "tags":
+        _refresh(word)
         return f"Overlay view: tags ({len(overlays)} overlay(s))."
 
     rendered, errors = 0, 0
@@ -72,9 +73,22 @@ def set_overlay_view(doc_path: str, mode: str) -> str:
     finally:
         shutil.rmtree(tmp_dir, ignore_errors=True)
 
+    _refresh(word)
     msg = f"Overlay view: {mode} ({rendered} overlay(s)"
     msg += f", {errors} error(s))" if errors else ")"
     return msg
+
+
+def _refresh(word) -> None:
+    """Force the live Word window to repaint after cross-process edits."""
+    try:
+        word.ScreenUpdating = True
+    except Exception:
+        pass
+    try:
+        word.ScreenRefresh()
+    except Exception:
+        pass
 
 
 # --- document / table helpers -------------------------------------------------
@@ -122,10 +136,19 @@ def _tag_of_table(table):
 def _restore_table(table) -> None:
     """Collapse to a single row and set the cell to the plain, visible tag."""
     tag = _tag_of_table(table) or ""
+    # Explicitly delete the preview images (overlay tables hold only our previews).
+    try:
+        for shape in list(table.Range.InlineShapes):
+            try:
+                shape.Delete()
+            except Exception:
+                pass
+    except Exception:
+        pass
     while table.Rows.Count > 1:
         table.Rows(table.Rows.Count).Delete()
     cell = table.Cell(1, 1)
-    cell.Range.Text = tag  # replaces text and removes any inline images
+    cell.Range.Text = tag  # replaces remaining text content
     cell.Range.Font.Hidden = False
 
 
@@ -238,7 +261,14 @@ def _mark_error(table, message: str) -> None:
 
 
 def _column_width(table):
-    try:
-        return table.Columns(1).Width
-    except Exception:
-        return None
+    """A sane image width in points. Word reports wdUndefined (a huge sentinel) for
+    autofit tables, which would make the picture overflow the cell — so clamp and fall
+    back to a reasonable default."""
+    for getter in (lambda: table.Columns(1).Width, lambda: table.Cell(1, 1).Width):
+        try:
+            width = getter()
+            if width and 0 < width < 1000:
+                return width
+        except Exception:
+            pass
+    return 400.0  # ~5.5 inches

--- a/src/report_compiler/document/overlay_preview.py
+++ b/src/report_compiler/document/overlay_preview.py
@@ -85,10 +85,7 @@ def set_overlay_view(doc_path: str, mode: str) -> str:
     finally:
         _set_cursor(word, _WD_CURSOR_NORMAL)
         _refresh(word)
-        try:
-            word.StatusBar = False  # hand the status bar back to Word
-        except Exception:
-            pass
+        _clear_status(word)
 
 
 def _status(word, message: str) -> None:
@@ -106,6 +103,23 @@ def _status(word, message: str) -> None:
 def _set_cursor(word, cursor) -> None:
     try:
         word.System.Cursor = cursor
+    except Exception:
+        pass
+
+
+def _clear_status(word) -> None:
+    """Relinquish the status bar back to Word. Setting the Python bool False marshals as
+    the text 'False' over COM, so pass a real VT_BOOL (falling back to an empty string)."""
+    try:
+        import pythoncom
+        from win32com.client import VARIANT
+
+        word.StatusBar = VARIANT(pythoncom.VT_BOOL, False)
+        return
+    except Exception:
+        pass
+    try:
+        word.StatusBar = ""
     except Exception:
         pass
 

--- a/src/report_compiler/document/overlay_preview.py
+++ b/src/report_compiler/document/overlay_preview.py
@@ -1,0 +1,231 @@
+"""In-document overlay preview: render OVERLAY pages into the live Word doc via COM.
+
+Driven from the COM server (``SetOverlayPreview``). Three modes:
+  - ``tags``  : restore every overlay to its canonical 1x1 tag table.
+  - ``quick`` : first selected page in the cell + a "+N more" caption.
+  - ``full``  : expand into one row per selected page so surrounding content reflows.
+
+The ``[[OVERLAY: …]]`` tag is always preserved as hidden text in the cell (and redundantly
+in each preview image's AltText), so the document still compiles at full resolution. The
+compile pipeline independently normalizes any leftover previews (see
+``DocxProcessor.normalize_overlay_previews``), so recovery never depends on this toggle.
+
+This module drives Word and can only be exercised on a real interactive session.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+
+import fitz  # PyMuPDF
+
+try:
+    import win32com.client
+except ImportError:  # pragma: no cover - non-Windows
+    win32com = None
+
+from ..core.config import Config
+from ..gui.overlay_logic import expand_selection, format_spec, parse_overlay_tag
+from ..pdf.content_analyzer import ContentAnalyzer
+from ..utils.logging_config import get_logger
+from ..utils.pdf_render import page_count
+
+_MARKER = Config.OVERLAY_PREVIEW_MARKER
+_WD_COLLAPSE_END = 0
+_WD_COLOR_RED = 255
+_QUICK_WIDTH_PX = 600
+_FULL_WIDTH_PX = 800
+
+
+def set_overlay_view(doc_path: str, mode: str) -> str:
+    """Apply ``mode`` ('tags' | 'quick' | 'full') to every overlay in the document."""
+    if win32com is None:
+        raise RuntimeError("pywin32 is not installed; cannot reach Word.")
+    if mode not in ("tags", "quick", "full"):
+        raise ValueError(f"Unknown overlay view mode: {mode}")
+
+    logger = get_logger()
+    word = win32com.client.GetActiveObject("Word.Application")
+    doc = _find_document(word, doc_path)
+
+    overlays = [t for t in doc.Tables if _is_overlay_table(t)]
+    # Restore-then-apply: every switch starts from canonical tags (idempotent).
+    for table in overlays:
+        _restore_table(table)
+
+    if mode == "tags":
+        return f"Overlay view: tags ({len(overlays)} overlay(s))."
+
+    rendered, errors = 0, 0
+    tmp_dir = tempfile.mkdtemp(prefix="rc_ovlprev_")
+    try:
+        for table in overlays:
+            try:
+                _apply_table(table, mode, doc_path, tmp_dir)
+                rendered += 1
+            except Exception as exc:  # noqa: BLE001 - one bad overlay shouldn't abort the rest
+                errors += 1
+                logger.warning("Overlay preview failed: %s", exc)
+                _mark_error(table, str(exc))
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    msg = f"Overlay view: {mode} ({rendered} overlay(s)"
+    msg += f", {errors} error(s))" if errors else ")"
+    return msg
+
+
+# --- document / table helpers -------------------------------------------------
+def _find_document(word, doc_path: str):
+    target = os.path.normcase(os.path.abspath(doc_path))
+    for doc in word.Documents:
+        try:
+            if os.path.normcase(os.path.abspath(doc.FullName)) == target:
+                return doc
+        except Exception:
+            continue
+    return word.ActiveDocument
+
+
+def _is_overlay_table(table) -> bool:
+    try:
+        if table.Columns.Count != 1:
+            return False
+    except Exception:
+        return False
+    return _tag_of_table(table) is not None
+
+
+def _tag_of_table(table):
+    """Tag string for an overlay table, from cell text (hidden ok) or image AltText."""
+    try:
+        for r in range(1, table.Rows.Count + 1):
+            match = Config.OVERLAY_REGEX.search(table.Cell(r, 1).Range.Text)
+            if match:
+                return match.group(0)
+    except Exception:
+        pass
+    try:
+        for shape in table.Range.InlineShapes:
+            descr = shape.AlternativeText or ""
+            if descr.startswith(_MARKER):
+                match = Config.OVERLAY_REGEX.search(descr)
+                if match:
+                    return match.group(0)
+    except Exception:
+        pass
+    return None
+
+
+def _restore_table(table) -> None:
+    """Collapse to a single row and set the cell to the plain, visible tag."""
+    tag = _tag_of_table(table) or ""
+    while table.Rows.Count > 1:
+        table.Rows(table.Rows.Count).Delete()
+    cell = table.Cell(1, 1)
+    cell.Range.Text = tag  # replaces text and removes any inline images
+    cell.Range.Font.Hidden = False
+
+
+# --- applying previews --------------------------------------------------------
+def _apply_table(table, mode: str, doc_path: str, tmp_dir: str) -> None:
+    tag = _tag_of_table(table)
+    parsed = parse_overlay_tag(tag)
+    if parsed is None:
+        raise ValueError("not an overlay tag")
+
+    pdf_path = os.path.abspath(os.path.join(os.path.dirname(doc_path), parsed["file"]))
+    if not os.path.isfile(pdf_path):
+        raise FileNotFoundError(f"missing: {parsed['file']}")
+
+    total = page_count(pdf_path)
+    indices = sorted(expand_selection(parsed["page"] or "", total)) or [0]
+    col_width = _column_width(table)
+
+    if mode == "quick":
+        pngs = _render_pages(pdf_path, indices[:1], parsed["crop"], tmp_dir, _QUICK_WIDTH_PX)
+        cell = table.Cell(1, 1)
+        _set_hidden_tag(cell, tag)
+        _insert_image(cell, pngs[0], tag, col_width)
+        caption = f"{os.path.basename(parsed['file'])} · p.{format_spec(set(indices))}"
+        if len(indices) > 1:
+            caption += f"  (+{len(indices) - 1} more)"
+        _append_caption(cell, caption)
+    else:  # full
+        pngs = _render_pages(pdf_path, indices, parsed["crop"], tmp_dir, _FULL_WIDTH_PX)
+        cell = table.Cell(1, 1)
+        _set_hidden_tag(cell, tag)
+        _insert_image(cell, pngs[0], tag, col_width)
+        for png in pngs[1:]:
+            table.Rows.Add()
+            new_cell = table.Cell(table.Rows.Count, 1)
+            new_cell.Range.Text = ""
+            _insert_image(new_cell, png, tag, col_width)
+
+
+def _render_pages(pdf_path, indices, crop, tmp_dir, width_px):
+    """Render selected pages to temp PNGs, applying the same crop the compiler would."""
+    analyzer = ContentAnalyzer()
+    out = []
+    with fitz.open(pdf_path) as doc:
+        for i in indices:
+            page = doc[i]
+            clip = analyzer.apply_content_cropping(page, crop)
+            zoom = width_px / clip.width if clip.width else 1.0
+            pix = page.get_pixmap(matrix=fitz.Matrix(zoom, zoom), clip=clip, alpha=False)
+            path = os.path.join(tmp_dir, f"ovl_{i}.png")
+            pix.save(path)
+            out.append(path)
+    return out
+
+
+def _set_hidden_tag(cell, tag: str) -> None:
+    cell.Range.Text = tag
+    cell.Range.Font.Hidden = True
+
+
+def _insert_image(cell, png_path: str, tag: str, col_width) -> None:
+    rng = cell.Range
+    rng.Collapse(_WD_COLLAPSE_END)
+    shape = rng.InlineShapes.AddPicture(FileName=png_path, LinkToFile=False, SaveWithDocument=True)
+    try:
+        shape.LockAspectRatio = -1  # msoTrue
+        if col_width:
+            shape.Width = col_width
+    except Exception:
+        pass
+    try:
+        shape.AlternativeText = f"{_MARKER}:{tag}"
+    except Exception:
+        pass
+
+
+def _append_caption(cell, text: str) -> None:
+    rng = cell.Range
+    rng.Collapse(_WD_COLLAPSE_END)
+    rng.Text = "\r" + text
+    rng.Font.Hidden = False
+
+
+def _mark_error(table, message: str) -> None:
+    """Show a red warning in the cell while keeping the tag (hidden) for recovery."""
+    try:
+        tag = _tag_of_table(table) or ""
+        cell = table.Cell(1, 1)
+        _set_hidden_tag(cell, tag)
+        rng = cell.Range
+        rng.Collapse(_WD_COLLAPSE_END)
+        rng.Text = "\r⚠ " + message
+        rng.Font.Hidden = False
+        rng.Font.Color = _WD_COLOR_RED
+    except Exception:
+        pass
+
+
+def _column_width(table):
+    try:
+        return table.Columns(1).Width
+    except Exception:
+        return None

--- a/src/report_compiler/document/overlay_preview.py
+++ b/src/report_compiler/document/overlay_preview.py
@@ -212,17 +212,32 @@ def _reset_cell(cell) -> None:
     cell.Range.Font.Hidden = False
 
 
-def _append_hidden_tag(cell, tag: str) -> None:
-    """Append the tag at the end of the cell and hide only that run (kept for compile)."""
+def _inside_end(cell):
+    """A collapsed range just *inside* the cell, before its end-of-cell marker.
+
+    A cell's Range ends at the cell marker; collapsing to that end and inserting there
+    spills content past the marker, which in the last cell of a row creates a brand-new
+    cell (column). Stepping back one character keeps inserts inside the cell.
+    """
     rng = cell.Range
+    try:
+        if rng.End - 1 >= rng.Start:
+            rng.End = rng.End - 1
+    except Exception:
+        pass
     rng.Collapse(_WD_COLLAPSE_END)
+    return rng
+
+
+def _append_hidden_tag(cell, tag: str) -> None:
+    """Append the tag inside the cell and hide only that run (kept for compile)."""
+    rng = _inside_end(cell)
     rng.Text = tag
     rng.Font.Hidden = True
 
 
 def _insert_image(cell, png_path: str, tag: str, col_width) -> None:
-    rng = cell.Range
-    rng.Collapse(_WD_COLLAPSE_END)
+    rng = _inside_end(cell)
     rng.Font.Hidden = False  # ensure the picture's run is not hidden-formatted
     shape = rng.InlineShapes.AddPicture(FileName=png_path, LinkToFile=False, SaveWithDocument=True)
     try:
@@ -238,8 +253,7 @@ def _insert_image(cell, png_path: str, tag: str, col_width) -> None:
 
 
 def _append_caption(cell, text: str) -> None:
-    rng = cell.Range
-    rng.Collapse(_WD_COLLAPSE_END)
+    rng = _inside_end(cell)
     rng.Text = "\r" + text
     rng.Font.Hidden = False
 
@@ -250,8 +264,7 @@ def _mark_error(table, message: str) -> None:
         tag = _tag_of_table(table) or ""
         cell = table.Cell(1, 1)
         _reset_cell(cell)
-        rng = cell.Range
-        rng.Collapse(_WD_COLLAPSE_END)
+        rng = _inside_end(cell)
         rng.Text = "⚠ " + message
         rng.Font.Hidden = False
         rng.Font.Color = _WD_COLOR_RED

--- a/src/report_compiler/document/overlay_preview.py
+++ b/src/report_compiler/document/overlay_preview.py
@@ -35,6 +35,8 @@ from ..utils.pdf_render import page_count
 _MARKER = Config.OVERLAY_PREVIEW_MARKER
 _WD_COLLAPSE_END = 0
 _WD_COLOR_RED = 255
+_WD_CURSOR_WAIT = 0  # WdCursorType: wait
+_WD_CURSOR_NORMAL = 2  # WdCursorType: normal
 _QUICK_WIDTH_PX = 600
 _FULL_WIDTH_PX = 800
 
@@ -51,32 +53,61 @@ def set_overlay_view(doc_path: str, mode: str) -> str:
     doc = _find_document(word, doc_path)
 
     overlays = [t for t in doc.Tables if _is_overlay_table(t)]
-    # Restore-then-apply: every switch starts from canonical tags (idempotent).
-    for table in overlays:
-        _restore_table(table)
-
-    if mode == "tags":
-        _refresh(word)
-        return f"Overlay view: tags ({len(overlays)} overlay(s))."
-
-    rendered, errors = 0, 0
-    tmp_dir = tempfile.mkdtemp(prefix="rc_ovlprev_")
+    total = len(overlays)
+    _set_cursor(word, _WD_CURSOR_WAIT)
     try:
-        for table in overlays:
-            try:
-                _apply_table(table, mode, doc_path, tmp_dir)
-                rendered += 1
-            except Exception as exc:  # noqa: BLE001 - one bad overlay shouldn't abort the rest
-                errors += 1
-                logger.warning("Overlay preview failed: %s", exc)
-                _mark_error(table, str(exc))
-    finally:
-        shutil.rmtree(tmp_dir, ignore_errors=True)
+        # Restore-then-apply: every switch starts from canonical tags (idempotent).
+        for i, table in enumerate(overlays, 1):
+            _status(word, f"Report Compiler: resetting overlay {i} of {total}…")
+            _restore_table(table)
 
-    _refresh(word)
-    msg = f"Overlay view: {mode} ({rendered} overlay(s)"
-    msg += f", {errors} error(s))" if errors else ")"
-    return msg
+        if mode == "tags":
+            return f"Overlay view: tags ({total} overlay(s))."
+
+        rendered, errors = 0, 0
+        tmp_dir = tempfile.mkdtemp(prefix="rc_ovlprev_")
+        try:
+            for i, table in enumerate(overlays, 1):
+                _status(word, f"Report Compiler: rendering overlay {i} of {total} ({mode})…")
+                try:
+                    _apply_table(table, mode, doc_path, tmp_dir)
+                    rendered += 1
+                except Exception as exc:  # noqa: BLE001 - one bad overlay shouldn't abort the rest
+                    errors += 1
+                    logger.warning("Overlay preview failed: %s", exc)
+                    _mark_error(table, str(exc))
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+        msg = f"Overlay view: {mode} ({rendered} overlay(s)"
+        msg += f", {errors} error(s))" if errors else ")"
+        return msg
+    finally:
+        _set_cursor(word, _WD_CURSOR_NORMAL)
+        _refresh(word)
+        try:
+            word.StatusBar = False  # hand the status bar back to Word
+        except Exception:
+            pass
+
+
+def _status(word, message: str) -> None:
+    """Show progress in Word's status bar and repaint so it's visible mid-operation."""
+    try:
+        word.StatusBar = message
+    except Exception:
+        pass
+    try:
+        word.ScreenRefresh()
+    except Exception:
+        pass
+
+
+def _set_cursor(word, cursor) -> None:
+    try:
+        word.System.Cursor = cursor
+    except Exception:
+        pass
 
 
 def _refresh(word) -> None:

--- a/src/report_compiler/document/overlay_preview.py
+++ b/src/report_compiler/document/overlay_preview.py
@@ -147,8 +147,9 @@ def _apply_table(table, mode: str, doc_path: str, tmp_dir: str) -> None:
     if mode == "quick":
         pngs = _render_pages(pdf_path, indices[:1], parsed["crop"], tmp_dir, _QUICK_WIDTH_PX)
         cell = table.Cell(1, 1)
-        _set_hidden_tag(cell, tag)
+        _reset_cell(cell)
         _insert_image(cell, pngs[0], tag, col_width)
+        _append_hidden_tag(cell, tag)
         caption = f"{os.path.basename(parsed['file'])} · p.{format_spec(set(indices))}"
         if len(indices) > 1:
             caption += f"  (+{len(indices) - 1} more)"
@@ -156,12 +157,13 @@ def _apply_table(table, mode: str, doc_path: str, tmp_dir: str) -> None:
     else:  # full
         pngs = _render_pages(pdf_path, indices, parsed["crop"], tmp_dir, _FULL_WIDTH_PX)
         cell = table.Cell(1, 1)
-        _set_hidden_tag(cell, tag)
+        _reset_cell(cell)
         _insert_image(cell, pngs[0], tag, col_width)
+        _append_hidden_tag(cell, tag)
         for png in pngs[1:]:
             table.Rows.Add()
             new_cell = table.Cell(table.Rows.Count, 1)
-            new_cell.Range.Text = ""
+            _reset_cell(new_cell)
             _insert_image(new_cell, png, tag, col_width)
 
 
@@ -181,14 +183,24 @@ def _render_pages(pdf_path, indices, crop, tmp_dir, width_px):
     return out
 
 
-def _set_hidden_tag(cell, tag: str) -> None:
-    cell.Range.Text = tag
-    cell.Range.Font.Hidden = True
+def _reset_cell(cell) -> None:
+    """Empty a cell and clear hidden formatting so inserted images stay visible."""
+    cell.Range.Text = ""
+    cell.Range.Font.Hidden = False
+
+
+def _append_hidden_tag(cell, tag: str) -> None:
+    """Append the tag at the end of the cell and hide only that run (kept for compile)."""
+    rng = cell.Range
+    rng.Collapse(_WD_COLLAPSE_END)
+    rng.Text = tag
+    rng.Font.Hidden = True
 
 
 def _insert_image(cell, png_path: str, tag: str, col_width) -> None:
     rng = cell.Range
     rng.Collapse(_WD_COLLAPSE_END)
+    rng.Font.Hidden = False  # ensure the picture's run is not hidden-formatted
     shape = rng.InlineShapes.AddPicture(FileName=png_path, LinkToFile=False, SaveWithDocument=True)
     try:
         shape.LockAspectRatio = -1  # msoTrue
@@ -214,12 +226,13 @@ def _mark_error(table, message: str) -> None:
     try:
         tag = _tag_of_table(table) or ""
         cell = table.Cell(1, 1)
-        _set_hidden_tag(cell, tag)
+        _reset_cell(cell)
         rng = cell.Range
         rng.Collapse(_WD_COLLAPSE_END)
-        rng.Text = "\r⚠ " + message
+        rng.Text = "⚠ " + message
         rng.Font.Hidden = False
         rng.Font.Color = _WD_COLOR_RED
+        _append_hidden_tag(cell, tag)
     except Exception:
         pass
 

--- a/src/report_compiler/gui/overlay_logic.py
+++ b/src/report_compiler/gui/overlay_logic.py
@@ -6,11 +6,37 @@ Kept separate from the PySide6 dialog so it can be unit-tested without a GUI or 
 from __future__ import annotations
 
 import os
-from typing import List, Set
+from typing import List, Optional, Set
 
+from report_compiler.core.config import Config
 from report_compiler.utils.page_selector import PageSelector
 
 _selector = PageSelector()
+
+
+def parse_overlay_tag(tag: str) -> Optional[dict]:
+    """Parse an ``[[OVERLAY: file, page=…, crop=…]]`` tag into its parts.
+
+    Returns ``{'file', 'page' (spec str or None), 'crop' (bool)}`` or None if not an
+    overlay tag. Mirrors the parameter handling in placeholder_parser.
+    """
+    match = Config.OVERLAY_REGEX.search(tag)
+    if not match:
+        return None
+    result = {"file": match.group(1).strip(), "page": None, "crop": Config.DEFAULT_CROP_ENABLED}
+    params = match.group(2)
+    if params:
+        for part in (p.strip() for p in params.split(",")):
+            if "=" in part:
+                key, value = part.split("=", 1)
+                key, value = key.strip().lower(), value.strip()
+                if key == "page":
+                    result["page"] = value
+                elif key == "crop":
+                    result["crop"] = value.lower() in ("true", "1", "yes", "on", "enabled")
+            elif part and result["page"] is None:
+                result["page"] = part
+    return result
 
 
 def expand_selection(spec: str, total_pages: int) -> Set[int]:

--- a/src/report_compiler/gui/pdf_render.py
+++ b/src/report_compiler/gui/pdf_render.py
@@ -1,34 +1,19 @@
-"""Raster rendering of PDF pages for GUI previews (PyMuPDF).
+"""GUI-side PDF rendering: re-exports the pure renderer and adds a cached QPixmap wrapper.
 
-Shared by all GUI features. ``render_page_png`` is pure PyMuPDF (testable without Qt);
-``render_page_pixmap`` wraps it into a QPixmap and is cached for the thumbnail grid.
+The pure functions live in ``report_compiler.utils.pdf_render`` so non-GUI code (the
+in-document overlay preview) can render without importing PySide6.
 """
 
 from __future__ import annotations
 
-import fitz  # PyMuPDF
-
-
-def page_count(pdf_path: str) -> int:
-    with fitz.open(pdf_path) as doc:
-        return len(doc)
-
-
-def render_page_png(pdf_path: str, page_index: int, target_width_px: int) -> bytes:
-    """Render one page to PNG bytes, scaled so its width is ~``target_width_px``."""
-    with fitz.open(pdf_path) as doc:
-        page = doc[page_index]
-        zoom = target_width_px / page.rect.width if page.rect.width else 1.0
-        pix = page.get_pixmap(matrix=fitz.Matrix(zoom, zoom), alpha=False)
-        return pix.tobytes("png")
-
+from report_compiler.utils.pdf_render import page_count, render_page_png  # noqa: F401 (re-export)
 
 _pixmap_cache: dict = {}
 
 
 def render_page_pixmap(pdf_path: str, page_index: int, target_width_px: int):
-    """Render a page to a cached QPixmap. Imported lazily so this module stays
-    importable (for the PNG path) without PySide6 installed."""
+    """Render a page to a cached QPixmap. PySide6 is imported lazily so this module
+    stays importable (for the re-exported PNG path) without PySide6 installed."""
     from PySide6.QtGui import QPixmap
 
     key = (pdf_path, page_index, target_width_px)

--- a/src/report_compiler/utils/pdf_render.py
+++ b/src/report_compiler/utils/pdf_render.py
@@ -1,0 +1,38 @@
+"""Pure PyMuPDF raster rendering of PDF pages (no GUI dependency).
+
+Used by both the GUI thumbnail grid and the in-document overlay preview. Returning PNG
+bytes keeps this importable without PySide6; the QPixmap wrapper lives in
+``report_compiler.gui.pdf_render``.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import fitz  # PyMuPDF
+
+
+def page_count(pdf_path: str) -> int:
+    with fitz.open(pdf_path) as doc:
+        return len(doc)
+
+
+def render_page_png(
+    pdf_path: str,
+    page_index: int,
+    target_width_px: int,
+    clip: Optional[Tuple[float, float, float, float]] = None,
+) -> bytes:
+    """Render one page to PNG bytes, scaled so the rendered width is ~``target_width_px``.
+
+    ``clip`` is an optional (x0, y0, x1, y1) rectangle in PDF points; when given, only
+    that region is rendered (used for crop-accurate previews). The zoom is derived from
+    the clipped width so the output still lands near ``target_width_px``.
+    """
+    with fitz.open(pdf_path) as doc:
+        page = doc[page_index]
+        clip_rect = fitz.Rect(clip) if clip is not None else None
+        width_pts = clip_rect.width if clip_rect is not None else page.rect.width
+        zoom = target_width_px / width_pts if width_pts else 1.0
+        pix = page.get_pixmap(matrix=fitz.Matrix(zoom, zoom), clip=clip_rect, alpha=False)
+        return pix.tobytes("png")

--- a/word_integration/ReportingTools.bas
+++ b/word_integration/ReportingTools.bas
@@ -422,7 +422,54 @@ Private Function GetImagePath() As String
             GetImagePath = "" ' User cancelled
         End If
     End With
-    
+
 End Function
+
+
+Public Sub OnOverlayViewChange(control As IRibbonControl, id As String, index As Integer)
+    ' Ribbon "Overlay view" dropdown: 0 = Tags, 1 = Quick preview, 2 = Full preview.
+    Dim mode As String
+    Select Case index
+        Case 1
+            mode = "quick"
+        Case 2
+            mode = "full"
+        Case Else
+            mode = "tags"
+    End Select
+    ApplyOverlayView mode
+End Sub
+
+Public Sub RepairOverlays(control As IRibbonControl)
+    ' Force every overlay back to its canonical tag form (recovery).
+    ApplyOverlayView "tags"
+End Sub
+
+Private Sub ApplyOverlayView(mode As String)
+    ' Drives the COM server to switch the whole document's overlay view.
+    Dim doc As Document
+    Dim localDocPath As String
+    Dim compiler As Object
+
+    Set doc = ActiveDocument
+    If doc.Path = "" Then
+        MsgBox "Please save the document first.", vbExclamation, "Save Document"
+        Exit Sub
+    End If
+    localDocPath = GetLocalPath(doc.FullName, , True)
+
+    On Error GoTo ComError
+    Set compiler = CreateObject("ReportCompiler.Application")
+    compiler.SetOverlayPreview localDocPath, mode
+    Set compiler = Nothing
+    Exit Sub
+
+ComError:
+    MsgBox "Could not reach the Report Compiler COM server." & vbCrLf & vbCrLf & _
+           "Register it first by running:" & vbCrLf & _
+           "    uvx report-compiler com-server register", _
+           vbCritical, "COM Server Not Registered"
+    Set compiler = Nothing
+End Sub
 
 

--- a/word_integration/report_compiler_UI.xml
+++ b/word_integration/report_compiler_UI.xml
@@ -34,6 +34,24 @@
                   supertip="Converts a single PDF page to high-quality SVG and inserts it as an image."/>
         </group>
         
+        <group id="groupOverlayPreview" label="Overlay Preview">
+          <dropDown id="ddOverlayView"
+                  label="View"
+                  onAction="OnOverlayViewChange"
+                  screentip="Overlay view"
+                  supertip="Switch all overlays between tags, quick preview, and full preview.">
+            <item id="ovTags" label="Tags"/>
+            <item id="ovQuick" label="Quick preview"/>
+            <item id="ovFull" label="Full preview"/>
+          </dropDown>
+          <button id="btnRepairOverlays"
+                  label="Repair overlays"
+                  onAction="RepairOverlays"
+                  imageMso="Refresh"
+                  screentip="Repair overlays"
+                  supertip="Force all overlays back to their tag form (recovery)."/>
+        </group>
+
         <group id="groupCompiler" label="Compiler">
           <button id="btnCompileReport"
                   label="Compile Report"


### PR DESCRIPTION
## What & why

Coworkers couldn't tell which pages an `[[OVERLAY: …]]` tag would insert or how they'd look, since an overlay is an empty 1×1 cell until compile. This adds a document-wide **Overlay view** ribbon dropdown — **Tags / Quick / Full** — that renders the real PDF pages into the live Word document, crop-accurate, driven by the COM server.

- **Quick**: first selected page in the cell + a `+N more` caption (cell stays small).
- **Full**: expands the overlay into one row per selected page, so surrounding content reflows exactly like the compiled output.
- **Tags**: restores the canonical `[[OVERLAY: …]]` text.

Stacks on `feat/word-gui-overlay` (overlay insert dialog), which stacks on #12 (COM server).

## Design

Spec committed in `docs/superpowers/specs/2026-06-24-in-document-overlay-preview-design.md`.

## Recovery is guaranteed at the compiler, not just the toggle

Preview images are low-res throwaways; the compiler never uses them — it reads the tag, resolves the original PDF, and renders it vector-accurate. The tag is preserved as hidden cell text **and** redundantly in each preview image's AltText (marker `RCPREVIEW`). Critically, `DocxProcessor.normalize_overlay_previews` runs **before parsing on every compile path (CLI/COM/button)**: it strips preview images and collapses expanded overlay tables back to canonical 1×1 tags. So a doc saved mid-preview always compiles correctly and at full resolution — even via the CLI, which would otherwise skip an expanded multi-row overlay.

## Components

- `document/overlay_preview.py` — live-Word engine (restore-then-apply) via COM `SetOverlayPreview(doc, mode)`.
- `document/docx_processor.py` — `normalize_overlay_previews` (compile-time recovery), hooked into `compiler._find_placeholders`.
- `utils/pdf_render.py` — pure renderer moved out of `gui/` (adds `clip=` for crop); `gui/pdf_render` keeps the QPixmap wrapper. `overlay_logic.parse_overlay_tag` added.
- `com_server.SetOverlayPreview`; `ReportingTools.bas` dropdown + Repair overlays; ribbon XML.

## Fixes found during on-machine testing (Word COM gotchas)

- Inline images were hidden because the whole cell was set `Font.Hidden` before insert — now hide only the tag run, insert images at an explicitly unhidden point.
- Inserting at a cell Range's end spilled past the end-of-cell marker and **created a new table column** — now insert just before the marker (`_inside_end`).
- Autofit tables report `wdUndefined` for column width → images overflowed; clamp with a sane fallback.
- Cross-process edits didn't repaint → `ScreenRefresh` after apply/restore.
- Revert now explicitly deletes the preview `InlineShapes`.
- Progress feedback (status bar "rendering N of M" + wait cursor) for many-overlay docs; status bar relinquished via a real `VT_BOOL` False (the Python bool marshalled as the text "False").

## Verification

- Headless: tag parsing, crop-`clip` PNG rendering, and the normalizer round-trip — expanded multi-row + hidden tag collapses to 1×1 with the tag intact and images stripped; recovery from a damaged tag via image AltText; non-overlay tables untouched; parser then finds the overlay.
- On a real Windows session: Tags/Quick/Full cycle, save-in-preview → compile recovers full-res output.

## Reviewer notes

- The live COM/Word manipulation (`SetOverlayPreview`) can't run in CI/sandbox; it was verified interactively. The compile-time recovery path and pure logic are fully covered headless.
- `SetOverlayPreview` is synchronous; for very large docs it could later move to the async job+poll model (status bar is the lightweight fit for now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)