### PR TITLE
Overlay insert dialog (PySide6) + Word GUI foundation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "typer>=0.9.0",
     "pywin32; sys_platform == 'win32'",
     "questionary>=2.0.1",
+    "PySide6>=6.6",
 ]
 
 [project.scripts]

--- a/src/report_compiler/com_server.py
+++ b/src/report_compiler/com_server.py
@@ -163,7 +163,13 @@ class ReportCompilerCOMServer:
     polls :meth:`GetJobStatus` / :meth:`GetJobMessage`.
     """
 
-    _public_methods_ = ["CompileAsync", "SvgImportAsync", "GetJobStatus", "GetJobMessage"]
+    _public_methods_ = [
+        "CompileAsync",
+        "SvgImportAsync",
+        "LaunchOverlayDialog",
+        "GetJobStatus",
+        "GetJobMessage",
+    ]
     _reg_clsid_ = CLSID
     _reg_progid_ = PROGID
     _reg_desc_ = DESC
@@ -194,6 +200,28 @@ class ReportCompilerCOMServer:
         )
         thread.start()
         return job_id
+
+    def LaunchOverlayDialog(self, doc_path, anchor):
+        """Spawn the Insert PDF Overlay GUI as its own process and return immediately.
+
+        Not part of the async-job model — this just launches a UI process, which then
+        attaches to Word itself to write back. Uses this interpreter (the stable tool
+        env) so PySide6 and the package are available.
+        """
+        subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "report_compiler.gui",
+                "overlay",
+                "--doc",
+                str(doc_path),
+                "--anchor",
+                str(anchor),
+            ],
+            close_fds=True,
+        )
+        return "launched"
 
     def GetJobStatus(self, job_id):
         job = _JOBS.get(str(job_id))

--- a/src/report_compiler/core/config.py
+++ b/src/report_compiler/core/config.py
@@ -21,7 +21,7 @@ class Config:
     
     # PDF processing defaults
     DEFAULT_PADDING = 32  # points
-    DEFAULT_CROP_ENABLED = True
+    DEFAULT_CROP_ENABLED = False
     
     # File handling
     TEMP_FILE_PREFIX = "~temp_"

--- a/src/report_compiler/gui/__init__.py
+++ b/src/report_compiler/gui/__init__.py
@@ -1,0 +1,6 @@
+"""PySide6 GUI dialogs for the Word integration (driven from the COM server).
+
+The dialogs run as their own process (launched by the COM server) and attach to the
+live Word instance via COM to write back. Pure, Qt-free logic lives in
+``overlay_logic`` so it can be unit-tested without PySide6 or Word.
+"""

--- a/src/report_compiler/gui/__main__.py
+++ b/src/report_compiler/gui/__main__.py
@@ -1,0 +1,37 @@
+"""Entry point for GUI dialogs: ``python -m report_compiler.gui <command> [opts]``.
+
+Launched by the COM server (e.g. ``LaunchOverlayDialog``) as its own process, or run
+manually for development.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="report_compiler.gui")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    overlay = sub.add_parser("overlay", help="Insert PDF overlay dialog")
+    overlay.add_argument("--doc", default="", help="Local path of the active Word document")
+    overlay.add_argument("--anchor", default="", help="Bookmark name to insert at")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "overlay":
+        from PySide6.QtWidgets import QApplication
+        from report_compiler.gui.overlay_dialog import OverlayDialog
+
+        app = QApplication(sys.argv)
+        dialog = OverlayDialog(doc_path=args.doc, anchor=args.anchor)
+        dialog.show()
+        return app.exec()
+
+    parser.error(f"unknown command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/report_compiler/gui/overlay_dialog.py
+++ b/src/report_compiler/gui/overlay_dialog.py
@@ -1,0 +1,288 @@
+"""The Insert PDF Overlay dialog (PySide6).
+
+Grid of page thumbnails with the selected pages highlighted, two-way synced with a
+page-range box. On Insert it builds the [[OVERLAY: ...]] tag and writes it back into the
+live Word document via ``word_writer``.
+"""
+
+from __future__ import annotations
+
+import os
+
+from PySide6.QtCore import QObject, Qt, QThread, Signal, Slot
+from PySide6.QtGui import QPixmap
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QDialog,
+    QFileDialog,
+    QFrame,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
+
+from report_compiler.gui import pdf_render, word_writer
+from report_compiler.gui.overlay_logic import (
+    build_overlay_tag,
+    expand_selection,
+    format_spec,
+    relative_pdf_path,
+)
+
+_THUMB_W = 120
+_COLS = 4
+_SEL_STYLE = "border: 2px solid #378ADD; border-radius: 6px; background: #E6F1FB;"
+_UNSEL_STYLE = "border: 1px solid #C9C9C4; border-radius: 6px; background: white;"
+
+
+class _ThumbWorker(QObject):
+    """Renders page PNGs off the UI thread; emits bytes per page."""
+
+    rendered = Signal(int, bytes)
+    done = Signal()
+
+    def __init__(self, pdf_path: str, count: int, width: int):
+        super().__init__()
+        self._pdf_path = pdf_path
+        self._count = count
+        self._width = width
+
+    @Slot()
+    def run(self) -> None:
+        for i in range(self._count):
+            try:
+                png = pdf_render.render_page_png(self._pdf_path, i, self._width)
+            except Exception:
+                png = b""
+            self.rendered.emit(i, png)
+        self.done.emit()
+
+
+class _PageThumb(QFrame):
+    """One clickable page thumbnail; click toggles selection."""
+
+    clicked = Signal(int)
+
+    def __init__(self, index: int):
+        super().__init__()
+        self._index = index
+        self.setFixedWidth(_THUMB_W + 16)
+        self.setStyleSheet(_UNSEL_STYLE)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(6, 6, 6, 6)
+        self._image = QLabel("…")
+        self._image.setAlignment(Qt.AlignCenter)
+        self._image.setMinimumHeight(int(_THUMB_W / 0.77))
+        self._number = QLabel(str(index + 1))
+        self._number.setAlignment(Qt.AlignCenter)
+        self._number.setStyleSheet("border: none; color: #5F5E5A; font-size: 11px;")
+        layout.addWidget(self._image)
+        layout.addWidget(self._number)
+
+    def set_pixmap(self, pixmap: QPixmap) -> None:
+        self._image.setPixmap(pixmap.scaledToWidth(_THUMB_W, Qt.SmoothTransformation))
+
+    def set_selected(self, selected: bool) -> None:
+        self.setStyleSheet(_SEL_STYLE if selected else _UNSEL_STYLE)
+
+    def mousePressEvent(self, event) -> None:  # noqa: N802 (Qt override)
+        self.clicked.emit(self._index)
+
+
+class OverlayDialog(QDialog):
+    def __init__(self, doc_path: str = "", anchor: str = "", parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Insert PDF overlay")
+        self.resize(620, 640)
+        self._doc_path = doc_path
+        self._anchor = anchor
+        self._pdf_path = ""
+        self._total = 0
+        self._selected: set[int] = set()
+        self._thumbs: list[_PageThumb] = []
+        self._syncing = False
+        self._thread: QThread | None = None
+
+        root = QVBoxLayout(self)
+
+        # PDF file row
+        file_row = QHBoxLayout()
+        file_row.addWidget(QLabel("PDF file"))
+        self._path_edit = QLineEdit()
+        self._path_edit.setReadOnly(True)
+        file_row.addWidget(self._path_edit, 1)
+        browse = QPushButton("Browse…")
+        browse.clicked.connect(self._on_browse)
+        file_row.addWidget(browse)
+        root.addLayout(file_row)
+
+        # Selection toolbar (select/deselect all + live count)
+        sel_bar = QHBoxLayout()
+        self._select_all_btn = QPushButton("Select all")
+        self._select_all_btn.clicked.connect(self._on_select_all)
+        self._deselect_all_btn = QPushButton("Deselect all")
+        self._deselect_all_btn.clicked.connect(self._on_deselect_all)
+        self._select_all_btn.setEnabled(False)
+        self._deselect_all_btn.setEnabled(False)
+        sel_bar.addWidget(self._select_all_btn)
+        sel_bar.addWidget(self._deselect_all_btn)
+        sel_bar.addStretch(1)
+        self._count_label = QLabel("")
+        self._count_label.setStyleSheet("color: #5F5E5A;")
+        sel_bar.addWidget(self._count_label)
+        root.addLayout(sel_bar)
+
+        # Thumbnail grid in a scroll area
+        self._grid_host = QWidget()
+        self._grid = QGridLayout(self._grid_host)
+        self._grid.setAlignment(Qt.AlignTop)
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setWidget(self._grid_host)
+        root.addWidget(scroll, 1)
+
+        # Page range + crop
+        opts = QHBoxLayout()
+        opts.addWidget(QLabel("Pages"))
+        self._pages_edit = QLineEdit()
+        self._pages_edit.setPlaceholderText("all  (e.g. 1-3, 5, 8-)")
+        self._pages_edit.textEdited.connect(self._on_pages_edited)
+        opts.addWidget(self._pages_edit, 1)
+        self._crop = QCheckBox("Auto-crop to content")
+        self._crop.setChecked(False)
+        opts.addWidget(self._crop)
+        root.addLayout(opts)
+
+        # Buttons
+        btns = QHBoxLayout()
+        btns.addStretch(1)
+        cancel = QPushButton("Cancel")
+        cancel.clicked.connect(self.reject)
+        btns.addWidget(cancel)
+        self._insert = QPushButton("Insert overlay")
+        self._insert.setDefault(True)
+        self._insert.setEnabled(False)
+        self._insert.clicked.connect(self._on_insert)
+        btns.addWidget(self._insert)
+        root.addLayout(btns)
+
+    # --- PDF loading ---------------------------------------------------------
+    def _on_browse(self) -> None:
+        start_dir = os.path.dirname(self._doc_path) if self._doc_path else ""
+        path, _ = QFileDialog.getOpenFileName(self, "Select a PDF", start_dir, "PDF files (*.pdf)")
+        if path:
+            self._load_pdf(path)
+
+    def _load_pdf(self, path: str) -> None:
+        try:
+            total = pdf_render.page_count(path)
+        except Exception as exc:
+            QMessageBox.critical(self, "Cannot open PDF", str(exc))
+            return
+        self._pdf_path = path
+        self._total = total
+        self._path_edit.setText(path)
+        self._build_grid()
+        # Default: all pages selected (empty box == all).
+        self._pages_edit.clear()
+        self._selected = set(range(total))
+        self._refresh_selection_styles()
+        self._insert.setEnabled(True)
+        self._select_all_btn.setEnabled(True)
+        self._deselect_all_btn.setEnabled(True)
+        self._start_render()
+
+    def _build_grid(self) -> None:
+        while self._grid.count():
+            item = self._grid.takeAt(0)
+            if item.widget():
+                item.widget().deleteLater()
+        self._thumbs = []
+        for i in range(self._total):
+            thumb = _PageThumb(i)
+            thumb.clicked.connect(self._on_thumb_clicked)
+            self._thumbs.append(thumb)
+            self._grid.addWidget(thumb, i // _COLS, i % _COLS)
+
+    def _start_render(self) -> None:
+        if self._thread is not None:
+            self._thread.quit()
+            self._thread.wait()
+        self._thread = QThread()
+        self._worker = _ThumbWorker(self._pdf_path, self._total, _THUMB_W * 2)
+        self._worker.moveToThread(self._thread)
+        self._thread.started.connect(self._worker.run)
+        self._worker.rendered.connect(self._on_thumb_rendered)
+        self._worker.done.connect(self._thread.quit)
+        self._thread.start()
+
+    @Slot(int, bytes)
+    def _on_thumb_rendered(self, index: int, png: bytes) -> None:
+        if png and 0 <= index < len(self._thumbs):
+            pixmap = QPixmap()
+            pixmap.loadFromData(png, "PNG")
+            self._thumbs[index].set_pixmap(pixmap)
+
+    # --- selection sync ------------------------------------------------------
+    def _on_pages_edited(self, text: str) -> None:
+        if self._syncing:
+            return
+        self._selected = expand_selection(text, self._total)
+        self._refresh_selection_styles()
+
+    def _on_thumb_clicked(self, index: int) -> None:
+        if index in self._selected:
+            self._selected.discard(index)
+        else:
+            self._selected.add(index)
+        self._sync_box_from_selection()
+        self._refresh_selection_styles()
+
+    def _on_select_all(self) -> None:
+        self._selected = set(range(self._total))
+        self._sync_box_from_selection()
+        self._refresh_selection_styles()
+
+    def _on_deselect_all(self) -> None:
+        self._selected = set()
+        self._sync_box_from_selection()
+        self._refresh_selection_styles()
+
+    def _sync_box_from_selection(self) -> None:
+        """Update the page-range box to match the current selection (no feedback loop)."""
+        self._syncing = True
+        self._pages_edit.setText(format_spec(self._selected))
+        self._syncing = False
+
+    def _refresh_selection_styles(self) -> None:
+        for i, thumb in enumerate(self._thumbs):
+            thumb.set_selected(i in self._selected)
+        self._count_label.setText(f"{len(self._selected)} of {self._total} pages selected")
+
+    # --- insert --------------------------------------------------------------
+    def _on_insert(self) -> None:
+        if not self._pdf_path:
+            return
+        if not self._selected:
+            QMessageBox.warning(self, "No pages", "Select at least one page to overlay.")
+            return
+        rel = relative_pdf_path(self._pdf_path, self._doc_path or self._pdf_path)
+        tag = build_overlay_tag(rel, self._selected, self._total, self._crop.isChecked())
+
+        if not self._doc_path:
+            # Standalone/dev mode (no Word attached): just echo the tag.
+            print(tag)
+            self.accept()
+            return
+        try:
+            word_writer.insert_overlay_table(self._doc_path, self._anchor, tag)
+        except Exception as exc:
+            QMessageBox.critical(self, "Insert failed", f"Could not insert into Word:\n{exc}")
+            return
+        self.accept()

--- a/src/report_compiler/gui/overlay_logic.py
+++ b/src/report_compiler/gui/overlay_logic.py
@@ -1,0 +1,74 @@
+"""Qt-free logic for the overlay dialog: page expansion, tag building, relative paths.
+
+Kept separate from the PySide6 dialog so it can be unit-tested without a GUI or Word.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import List, Set
+
+from report_compiler.utils.page_selector import PageSelector
+
+_selector = PageSelector()
+
+
+def expand_selection(spec: str, total_pages: int) -> Set[int]:
+    """Resolve a page-spec string to a concrete set of 0-based page indices.
+
+    Reuses ``PageSelector.parse_specification`` and clamps to the document size.
+    Empty/blank spec means "all pages".
+    """
+    selection = _selector.parse_specification(spec)
+    if selection["use_all"]:
+        return set(range(total_pages))
+
+    pages: Set[int] = set(selection["pages"])
+    open_start = selection["open_range_start"]
+    if open_start is not None:
+        pages |= set(range(open_start, total_pages))
+    return {p for p in pages if 0 <= p < total_pages}
+
+
+def format_spec(pages_zero_based: Set[int]) -> str:
+    """Serialize a set of 0-based page indices to a compact 1-based spec ("1-3, 5")."""
+    if not pages_zero_based:
+        return ""
+    # PageSelector.format_page_list collapses runs into ranges; feed it 1-based pages.
+    one_based = sorted(p + 1 for p in pages_zero_based)
+    return _selector.format_page_list(one_based, one_based=True)
+
+
+def relative_pdf_path(pdf_path: str, doc_path: str) -> str:
+    """Path of ``pdf_path`` relative to the document's folder, using forward slashes.
+
+    Falls back to the absolute path when the two are on different drives (Windows),
+    where a relative path is impossible.
+    """
+    doc_dir = os.path.dirname(doc_path)
+    try:
+        rel = os.path.relpath(pdf_path, doc_dir)
+    except ValueError:
+        rel = os.path.abspath(pdf_path)
+    return rel.replace(os.sep, "/")
+
+
+def build_overlay_tag(
+    rel_path: str,
+    selected_pages_zero_based: Set[int],
+    total_pages: int,
+    crop: bool,
+) -> str:
+    """Build an ``[[OVERLAY: ...]]`` tag.
+
+    Omits ``page=`` when every page is selected (the parser treats absent page as all).
+    Cropping defaults to off, so only the on case is written (``crop=true``); when off we
+    omit ``crop=`` entirely to keep the tag clean.
+    """
+    tag = f"[[OVERLAY: {rel_path}"
+    if selected_pages_zero_based and len(selected_pages_zero_based) < total_pages:
+        tag += f", page={format_spec(selected_pages_zero_based)}"
+    if crop:
+        tag += ", crop=true"
+    tag += "]]"
+    return tag

--- a/src/report_compiler/gui/pdf_render.py
+++ b/src/report_compiler/gui/pdf_render.py
@@ -1,0 +1,47 @@
+"""Raster rendering of PDF pages for GUI previews (PyMuPDF).
+
+Shared by all GUI features. ``render_page_png`` is pure PyMuPDF (testable without Qt);
+``render_page_pixmap`` wraps it into a QPixmap and is cached for the thumbnail grid.
+"""
+
+from __future__ import annotations
+
+import fitz  # PyMuPDF
+
+
+def page_count(pdf_path: str) -> int:
+    with fitz.open(pdf_path) as doc:
+        return len(doc)
+
+
+def render_page_png(pdf_path: str, page_index: int, target_width_px: int) -> bytes:
+    """Render one page to PNG bytes, scaled so its width is ~``target_width_px``."""
+    with fitz.open(pdf_path) as doc:
+        page = doc[page_index]
+        zoom = target_width_px / page.rect.width if page.rect.width else 1.0
+        pix = page.get_pixmap(matrix=fitz.Matrix(zoom, zoom), alpha=False)
+        return pix.tobytes("png")
+
+
+_pixmap_cache: dict = {}
+
+
+def render_page_pixmap(pdf_path: str, page_index: int, target_width_px: int):
+    """Render a page to a cached QPixmap. Imported lazily so this module stays
+    importable (for the PNG path) without PySide6 installed."""
+    from PySide6.QtGui import QPixmap
+
+    key = (pdf_path, page_index, target_width_px)
+    cached = _pixmap_cache.get(key)
+    if cached is not None:
+        return cached
+
+    png = render_page_png(pdf_path, page_index, target_width_px)
+    pixmap = QPixmap()
+    pixmap.loadFromData(png, "PNG")
+    _pixmap_cache[key] = pixmap
+    return pixmap
+
+
+def clear_cache() -> None:
+    _pixmap_cache.clear()

--- a/src/report_compiler/gui/word_writer.py
+++ b/src/report_compiler/gui/word_writer.py
@@ -1,0 +1,51 @@
+"""Write back to the live Word document via COM (used by the GUI dialogs).
+
+The dialog runs in its own process; it attaches to the already-running Word instance
+with ``GetActiveObject`` and inserts at a bookmark that the VBA launcher dropped at the
+user's selection. This mirrors the table insertion the VBA used to do directly.
+"""
+
+from __future__ import annotations
+
+import os
+
+try:
+    import win32com.client
+except ImportError:  # pragma: no cover - non-Windows
+    win32com = None
+
+
+def _find_document(word, doc_path: str):
+    """Return the open Document matching doc_path, else the active document."""
+    target = os.path.normcase(os.path.abspath(doc_path))
+    for doc in word.Documents:
+        try:
+            if os.path.normcase(os.path.abspath(doc.FullName)) == target:
+                return doc
+        except Exception:
+            continue
+    return word.ActiveDocument
+
+
+def insert_overlay_table(doc_path: str, anchor_bookmark: str, tag_text: str) -> None:
+    """Insert a 1x1 borderless table containing ``tag_text`` at the anchor bookmark.
+
+    Raises on failure so the caller can surface a message.
+    """
+    if win32com is None:
+        raise RuntimeError("pywin32 is not installed; cannot reach Word.")
+
+    word = win32com.client.GetActiveObject("Word.Application")
+    doc = _find_document(word, doc_path)
+
+    if anchor_bookmark and doc.Bookmarks.Exists(anchor_bookmark):
+        rng = doc.Bookmarks(anchor_bookmark).Range
+    else:
+        rng = word.Selection.Range
+
+    table = doc.Tables.Add(rng, 1, 1)
+    table.Borders.Enable = False
+    table.Cell(1, 1).Range.Text = tag_text
+
+    if anchor_bookmark and doc.Bookmarks.Exists(anchor_bookmark):
+        doc.Bookmarks(anchor_bookmark).Delete

--- a/src/report_compiler/pdf/overlay_processor.py
+++ b/src/report_compiler/pdf/overlay_processor.py
@@ -4,6 +4,7 @@ PDF overlay processing for table-based insertions.
 
 import fitz  # PyMuPDF
 from typing import Dict, List, Any
+from ..core.config import Config
 from ..utils.conversions import points_to_inches
 from ..utils.page_selector import PageSelector
 from ..utils.logging_config import get_overlay_logger
@@ -101,7 +102,7 @@ class OverlayProcessor:
             placeholder = data['placeholder']
             # Use the resolved absolute path, which is guaranteed by the compiler.
             pdf_path = placeholder['resolved_path']
-            crop_enabled = placeholder.get('crop_enabled', True)
+            crop_enabled = placeholder.get('crop_enabled', Config.DEFAULT_CROP_ENABLED)
             # Log the original path for user-facing messages.
             self.logger.info("  Processing overlay %d: %s", idx, placeholder['file_path'])
 

--- a/src/report_compiler/utils/page_selector.py
+++ b/src/report_compiler/utils/page_selector.py
@@ -31,28 +31,33 @@ class PageSelector:
                 'open_range_start': None,
                 'total_specified': 0
             }
-        
+
         pages = []
         open_range_start = None
-        
-        # Find all matches in the specification
-        matches = self.page_spec_regex.findall(page_spec.strip())
-        
-        for match in matches:
-            start_str, end_str = match
-            start = int(start_str)
-            
-            # Check if this is truly an open range (has a dash) vs just a single page
-            if end_str == '' and '-' in page_spec:  # Open range (e.g., "9-")
-                open_range_start = start - 1  # Convert to 0-based
-                break
-            elif end_str:  # Closed range (e.g., "1-3")
-                end = int(end_str)
-                for page_num in range(start, end + 1):
-                    pages.append(page_num - 1)  # Convert to 0-based
-            else:  # Single page (e.g., "7")
-                pages.append(start - 1)  # Convert to 0-based
-        
+
+        # Parse each comma-separated token independently. Whether a token is an open
+        # range ("9-") must be decided from the token itself, not from whether the whole
+        # spec contains a dash — otherwise "1-3,5" wrongly reads "5" as open-ended.
+        for token in page_spec.split(','):
+            token = token.strip()
+            if not token:
+                continue
+            try:
+                if '-' in token:  # Range: "1-3" (closed) or "9-" (open)
+                    start_str, end_str = token.split('-', 1)
+                    start = int(start_str.strip())
+                    end_str = end_str.strip()
+                    if end_str == '':
+                        open_range_start = start - 1  # Convert to 0-based
+                    else:
+                        end = int(end_str)
+                        for page_num in range(start, end + 1):
+                            pages.append(page_num - 1)  # Convert to 0-based
+                else:  # Single page: "7"
+                    pages.append(int(token) - 1)  # Convert to 0-based
+            except ValueError:
+                continue  # Skip malformed tokens
+
         return {
             'pages': sorted(list(set(pages))),  # Remove duplicates and sort
             'use_all': False,

--- a/word_integration/ReportingTools.bas
+++ b/word_integration/ReportingTools.bas
@@ -62,61 +62,46 @@ Public Sub InsertAppendixPlaceholder(control As IRibbonControl)
 End Sub
 
 Public Sub InsertOverlayPlaceholder(control As IRibbonControl)
-    ' Inserts a table-based placeholder for overlaying a PDF page.
-    
-    Dim pdfPath As String
+    ' Launches the PDF Overlay dialog via the COM server. The dialog (Python/PySide6)
+    ' shows page previews, lets the user pick a page range, then inserts the
+    ' [[OVERLAY: ...]] placeholder back into this document at the bookmark below.
+
+    Dim doc As Document
     Dim localDocPath As String
-    Dim localPdfPath As String
-    Dim relativePdfPath As String
-    Dim pageRange As String
-    Dim cropText As String
-    Dim placeholderText As String
-    Dim tbl As Table
-    Dim cc As ContentControl
-    
+    Dim anchorName As String
+    Dim compiler As Object
+
+    Set doc = ActiveDocument
+
     ' Ensure the document is saved before creating a relative path.
-    If ActiveDocument.Path = "" Then
+    If doc.Path = "" Then
         MsgBox "Please save the document first to create a relative path for the overlay.", vbExclamation, "Save Document"
         Exit Sub
     End If
 
-    ' Get the path to the PDF file from the user.
-    pdfPath = GetPdfPath()
-    If pdfPath = "" Then Exit Sub ' User cancelled
-    
-    ' Convert OneDrive/SharePoint paths to local paths for both document and selected PDF
-    localDocPath = GetLocalPath(ActiveDocument.Path, , True)
-    localPdfPath = GetLocalPath(pdfPath, , True)
-    
-    ' Calculate relative path using LibFileTools
-    relativePdfPath = GetRelativePath(localPdfPath, localDocPath)
-    
-    ' Prompt for optional parameters.
-    pageRange = InputBox("Enter an optional page range (e.g., 1-3,5). Leave blank for all pages.", "Overlay Page Selection")
-    
-    If MsgBox("Auto-crop the overlay to its content (removes whitespace)?", vbYesNo + vbQuestion, "Overlay Cropping") = vbNo Then
-        cropText = ", crop=false"
-    End If
-    
-    ' Construct the placeholder string.
-    placeholderText = "[[OVERLAY: " & relativePdfPath
-    If pageRange <> "" Then
-        placeholderText = placeholderText & ", page=" & pageRange
-    End If
-    placeholderText = placeholderText & cropText & "]]"
-    
-    ' Insert a 1x1 table at the current selection.
-    Set tbl = ActiveDocument.Tables.Add(Range:=Selection.Range, NumRows:=1, NumColumns:=1)
-    
-    ' Style the table to make it visible as a placeholder.
-    With tbl.Borders
-        .Enable = False
+    ' Resolve OneDrive/SharePoint path to a local path (kept in LibFileTools).
+    localDocPath = GetLocalPath(doc.FullName, , True)
 
-    End With
-    
-    ' Insert the placeholder text into the cell as plain text (no content control).
-    tbl.Cell(1, 1).Range.Text = placeholderText
-    
+    ' Drop a bookmark at the current selection so the dialog knows where to insert.
+    anchorName = "RC_OverlayAnchor"
+    On Error Resume Next
+    doc.Bookmarks(anchorName).Delete
+    On Error GoTo 0
+    doc.Bookmarks.Add Name:=anchorName, Range:=Selection.Range
+
+    ' Launch the dialog (returns immediately; Word stays responsive).
+    On Error GoTo ComError
+    Set compiler = CreateObject("ReportCompiler.Application")
+    compiler.LaunchOverlayDialog localDocPath, anchorName
+    Set compiler = Nothing
+    Exit Sub
+
+ComError:
+    MsgBox "Could not reach the Report Compiler COM server." & vbCrLf & vbCrLf & _
+           "Register it first by running:" & vbCrLf & _
+           "    uvx report-compiler com-server register", _
+           vbCritical, "COM Server Not Registered"
+    Set compiler = Nothing
 End Sub
 
 Public Sub InsertImagePlaceholder(control As IRibbonControl)


### PR DESCRIPTION
## What & why

First GUI feature on top of the COM server (#12): a print-style **Insert Overlay** dialog so users pick PDF pages visually instead of typing into input boxes. Also establishes the shared GUI foundation reused by later features.

Stacks on #12 (COM server). The in-document overlay preview (#13) stacks on this branch.

## What's in it

**GUI foundation (`src/report_compiler/gui/`)**
- `pdf_render` — PyMuPDF raster rendering + thumbnail cache (QPixmap wrapper).
- `overlay_logic` — Qt-free, unit-testable: page-spec expansion, compact-spec formatting, relative path, tag building.
- `word_writer` — attaches to the running Word via `GetActiveObject` and inserts at a bookmark.
- `overlay_dialog` — the PySide6 dialog: thumbnail grid with selected pages highlighted, two-way sync with the page-range box, select/deselect-all + live count, auto-crop checkbox, background-thread rendering.
- `__main__` — `python -m report_compiler.gui overlay …` entry (also runnable standalone for dev).

**Integration**
- `com_server.LaunchOverlayDialog` spawns the dialog as its own process.
- `ReportingTools.bas`: `InsertOverlayPlaceholder` is now a thin launcher (drops a bookmark, calls the COM method); placeholder building moved to Python.
- `pyproject`: adds PySide6.

## Behavior changes / fixes

- Fixed a real bug in the shared `PageSelector.parse_specification`: open-range detection checked the whole string, so `page=1-3,5` misread `5` as `5-` (overlaying pages 5→end). Now parsed per comma token — this also corrects existing compile output.
- Auto-crop now defaults **off** (`Config.DEFAULT_CROP_ENABLED=False`, checkbox unchecked); the tag emits `crop=true` only when enabled.

## Verification

- Unit/logic tests pass (page expansion + compact-spec round-trip, tag building, relative-path incl. different-drive fallback, PageSelector regressions).
- Headless (offscreen) dialog smoke test: loads a multi-page PDF, renders all thumbnails, both sync directions correct, select/deselect-all + count, Insert builds the right tag.
- The COM launch + Word write-back is verified on a real interactive session (can't run in CI/sandbox).

## Reviewer notes

- PySide6 is a large (~100 MB) dependency added to the tool env — a one-time foundation cost shared by all GUI features.
- The `.dotm`/`vbaProject.bin` are git-ignored build artifacts (per #12); after pulling, rebuild with `word-integration build-template`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)