### PR TITLE
Integrate Word GUI features into main + rewrite README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,309 +1,147 @@
 # Report Compiler
 
-A powerful automated tool for engineering teams to create professional PDF reports by embedding PDF content directly into Word documents. Write your reports in Word, add simple placeholders for external PDFs, and compile everything into a polished final report with a single command.
+**Build polished PDF reports straight from Microsoft Word.** Write your report normally, drop in your drawings, calculations, and appendices with a few ribbon buttons, and click **Compile** to get one clean PDF with everything stitched together.
 
-## What It Does
+No more printing to PDF, re-combining files by hand, or fixing page order every time a drawing changes.
 
-Transform your Word documents into comprehensive PDF reports by:
+![The Reporting Tools ribbon in Word](docs/images/ribbon.png)
 
-- **Adding PDF placeholders** in your Word document using simple tags
-- **Automatically inserting** external PDF content (drawings, calculations, appendices)
-- **Precisely positioning** PDF overlays within tables or merging full pages
-- **Compiling everything** into a single professional PDF report
+---
 
-Perfect for engineering reports, technical documentation, and any workflow where you need to combine Word content with external PDF files.
+## What you can do
 
-## Quick Example
+Inside Word you get a **Reporting Tools** tab with buttons for:
 
-1. **Write your report in Word** with placeholders:
+| Button | What it does |
+|--------|--------------|
+| **Insert Appendix** | Add an entire PDF (or specific pages) as full pages in your report |
+| **Insert Overlay** | Drop a PDF page (e.g. a sketch or detail) into a box, sized to fit, with a live page picker |
+| **Insert Image** | Place an image file (PNG, JPG, …) into a box |
+| **Insert PDF Page (Image)** | Convert a PDF page to a crisp image and insert it |
+| **Overlay view** | Flip the whole document between *Tags*, *Quick preview*, and *Full preview* so you can see exactly which pages will be inserted |
+| **Link manager** | See every linked file in one list, check which paths are valid, and fix broken links |
+| **Compile Report** | Turn the whole document into the final PDF |
 
-   ```text
-   This is my engineering report. 
-   
-   [[INSERT: calculations/load_analysis.pdf:1-3]]
-   
-   The table below shows the design sketch:
-   ┌─────────────────────────────────────┐
-   │ [[OVERLAY: drawings/sketch.pdf]]    │
-   └─────────────────────────────────────┘
-   
-   Here's the company logo:
-   ┌─────────────────────────────────────┐
-   │ [[IMAGE: assets/logo.png]]          │
-   └─────────────────────────────────────┘
-   ```
+You keep writing in Word the way you always have. The buttons just insert little **placeholders** that say "put this PDF here," and **Compile** replaces them with the real content.
 
-2. **Run the compiler**:
+---
 
-   ```bash
-   report-compiler report.docx final_report.pdf
-   ```
+## A typical workflow
 
-3. **Get a professional PDF** with all content seamlessly integrated!
+1. Write your report in Word.
+2. Where you want a drawing or appendix, click **Insert Overlay** or **Insert Appendix** and pick the file.
+3. (Optional) Use **Overlay view → Full preview** to see how the inserted pages will look in place.
+4. Click **Compile Report**. A finished PDF is created next to your document.
 
-## Installation
+That's it. If a drawing changes, just replace the file and re-compile — the report updates itself.
 
-### Option 1: Using uvx (Recommended)
+### Insert Overlay — pick exactly the pages you want
 
-The easiest way to install and run Report Compiler is with [uvx](https://docs.astral.sh/uv/guides/tools/):
+When you click **Insert Overlay**, a window shows thumbnails of the PDF's pages. Type a page range or click thumbnails; the selected pages are highlighted so you always know what you're inserting.
 
-```bash
-# Install uv if not already installed. Required version of python will be installed automatically by uv.
-winget install --id=astral-sh.uv  -e
+![The Insert Overlay dialog with page thumbnails](docs/images/overlay-dialog.png)
 
-# Install and run directly (no permanent installation)
-uvx report-compiler@latest compile report.docx output.pdf
+### Overlay view — preview in place
 
-# Or install globally for repeated use
-uvx install report-compiler
-report-compiler compile report.docx output.pdf
-```
+By default overlays show as small placeholders. Switch **Overlay view** to **Full preview** to render the actual pages right in the document and see how everything reflows; switch back to **Tags** when you're done. (Previews are just for looking — your final compile always uses the original full-resolution PDFs.)
 
-### Option 2: Traditional Installation
+![A document showing overlays in Full preview](docs/images/overlay-preview.png)
 
-```bash
-# Install from PyPI
-pip install report-compiler
+### Link manager — keep your references healthy
 
-# Or install from source
-git clone https://github.com/your-repo/report-compiler.git
-cd report-compiler
-pip install -e .
-```
+Open the **Link manager** to see every file your report links to, whether each path is still valid, and jump to or relink anything that moved.
 
-### Word Integration (Optional)
+![The Link manager window](docs/images/link-manager.png)
 
-For enhanced productivity, install the Word add-in that provides buttons to insert placeholders and compile reports:
+---
 
-**Option 1: Using uvx (Recommended)**
+## One-time setup (Windows)
 
-```bash
-# Install Word integration template
+You only do this once per computer. If you're not comfortable with the steps below, your IT or a colleague can run them for you — after that, everything happens with the Word buttons.
+
+Open **PowerShell** and run:
+
+```powershell
+# 1. Install uv (the small tool that runs Report Compiler). Skip if already installed.
+winget install --id=astral-sh.uv -e
+
+# 2. Turn on the Word buttons (registers the helper that Word talks to — no admin needed)
+uvx report-compiler com-server register
+
+# 3. Add the Report Compiler ribbon to Word
 uvx report-compiler word-integration install
-
-# Check installation status
-uvx report-compiler word-integration status
-
-# Update to latest version
-uvx report-compiler word-integration update
-
-# Remove integration
-uvx report-compiler word-integration remove
 ```
 
-**Option 2: Manual Installation**
+Then **restart Word** — you'll see the **Reporting Tools** tab.
 
-1. **Copy the template file** to your Word templates folder:
+To check or undo the setup later:
 
-   ```bash
-   # Download and copy ReportCompilerTemplate.dotm to:
-   # Windows: %APPDATA%\Microsoft\Word\STARTUP\
-   ```
-
-2. **Restart Word** - you'll see new "Report Compiler" ribbon buttons
-
-3. **Use the buttons** to insert placeholders instead of typing them manually
-
-## Requirements
-
-- **Windows** (for Word automation)
-- **Microsoft Word** installed
-- **Python 3.7+**
-
-## Usage
-
-### Command Line Interface
-
-#### Basic Compilation
-
-```bash
-# Compile a Word document to PDF
-report-compiler compile input.docx output.pdf
-
-# Enable debug mode (keeps temporary files)
-report-compiler compile input.docx output.pdf --keep-temp
-
-# Verbose logging
-report-compiler compile input.docx output.pdf --verbose
+```powershell
+uvx report-compiler com-server status        # is the helper registered?
+uvx report-compiler word-integration status   # is the ribbon installed?
+uvx report-compiler word-integration remove    # remove the ribbon
 ```
 
-> The output path is normalized to end in `.pdf` automatically, so
-> `report-compiler compile input.docx output` writes `output.pdf`.
+**Requirements:** Windows, Microsoft Word, and an internet connection the first time (uv downloads what it needs, including the right Python). See [WORD_INTEGRATION.md](WORD_INTEGRATION.md) for a detailed setup and troubleshooting guide.
 
-#### Temporary Files and Caching
+---
 
-Temporary working files are written to the operating system's temp folder
-(not next to your document). This avoids OneDrive/SharePoint sync locks and
-"Files On‑Demand" placeholder issues that can otherwise cause intermittent
-conversion failures.
+## If something goes wrong
 
-Compiled sub-document inserts (recursively compiled `.docx` appendices) are
-cached, so re-running a report — for example after a late-stage failure —
-reuses appendices that already compiled instead of re-converting every one
-through Word. Cache entries are invalidated automatically when a source
-document or any file it references changes.
+| Message | What to do |
+|---------|------------|
+| *"Please save the document first"* | Save your Word document, then try again (links are stored relative to where the document lives). |
+| *"COM Server Not Registered"* | Run `uvx report-compiler com-server register` once, then retry. |
+| A link shows **Missing** in the Link manager | The file moved or was renamed — use **Relink** to point it at the new location. |
+| Compile fails on a PDF | Open the Link manager to find the broken link, or check the page numbers exist in the source PDF. |
 
-```bash
-# Use a custom temp directory (overrides the OS temp folder)
-report-compiler compile input.docx output.pdf --temp-dir D:\rc-temp
+---
 
-# Use a custom cache directory
-report-compiler compile input.docx output.pdf --cache-dir D:\rc-cache
+## For power users — command line
 
-# Disable the compiled-document cache for this run
-report-compiler compile input.docx output.pdf --no-cache
+Everything the buttons do can also be run from a terminal.
+
+```powershell
+# Compile a document to PDF (output defaults to the same name with .pdf)
+uvx report-compiler compile report.docx report.pdf
+
+# Convert PDF page(s) to SVG
+uvx report-compiler svg-import drawing.pdf out.svg --page 1-3
+
+# Interactive menu (compile, convert, manage the Word integration)
+uvx report-compiler
 ```
 
-Both locations can also be set via the `REPORT_COMPILER_TEMP_DIR` and
-`REPORT_COMPILER_CACHE_DIR` environment variables.
+### Placeholder reference
 
-#### PDF to SVG Conversion
-
-```bash
-# Convert single page
-report-compiler svg-import input.pdf output.svg --page 3
-
-# Convert multiple pages
-report-compiler svg-import input.pdf output.svg --page 1-5
-
-# Convert all pages
-report-compiler svg-import input.pdf output.svg --page all
-```
-
-### Using Placeholders in Word
-
-There are two types of placeholders you can use:
-
-#### 1. INSERT Placeholders (Full Page Merging)
-
-Use `INSERT` placeholders to add complete PDF pages into your document. Place these in standalone paragraphs:
+The buttons insert these tags for you, but you can also type them by hand. All paths are relative to the Word document (absolute paths also work).
 
 ```text
-[[INSERT: appendices/structural_analysis.pdf]]
-[[INSERT: calculations/load_analysis.pdf:1-5]]
-[[INSERT: external/report.pdf:2,4,6]]
+[[INSERT: appendices/calcs.pdf]]            All pages of a PDF as full pages
+[[INSERT: appendices/calcs.pdf:1-3,7]]      Specific pages (1–3 and 7)
+[[INSERT: chapters/intro.docx]]             Another Word doc, compiled and inserted
+
+[[OVERLAY: drawings/sketch.pdf]]            A PDF page placed in a 1-cell table
+[[OVERLAY: drawings/sketch.pdf, page=2]]    A specific page
+[[OVERLAY: drawings/sketch.pdf, crop=true]] Trim surrounding whitespace
+
+[[IMAGE: photos/site.png]]                  An image in a 1-cell table
+[[IMAGE: photos/site.png, width=3in]]       With a set width
 ```
 
-**Page Selection Options:**
+Page ranges accept single pages (`5`), ranges (`1-3`), lists (`1,3,5`), open ranges (`2-`), and combinations (`1-3,7,9-`).
 
-- `[[INSERT: file.pdf]]` - All pages
-- `[[INSERT: file.pdf:5]]` - Page 5 only
-- `[[INSERT: file.pdf:1-3]]` - Pages 1, 2, and 3
-- `[[INSERT: file.pdf:1,3,5]]` - Pages 1, 3, and 5
-- `[[INSERT: file.pdf:2-]]` - Pages 2 to end
-- `[[INSERT: file.pdf:1-3,7,9-]]` - Combined: pages 1-3, 7, and 9 to end
+### Working files and caching
 
-#### 2. OVERLAY Placeholders (Table-Based Positioning)
+Temporary files go to your system temp folder (not next to the document, which avoids OneDrive/SharePoint sync issues), and compiled appendices are cached so re-runs are fast. Override with `--temp-dir` / `--cache-dir` or the `REPORT_COMPILER_TEMP_DIR` / `REPORT_COMPILER_CACHE_DIR` environment variables; disable caching with `--no-cache`.
 
-Use `OVERLAY` placeholders to position PDF content precisely within tables. Place these inside single-cell tables:
+---
 
-```text
-[[OVERLAY: drawings/sketch.pdf]]
-[[OVERLAY: diagrams/detail.pdf, page=2]]
-[[OVERLAY: sketches/plan.pdf, page=1-3]]
-[[OVERLAY: drawings/full_page.pdf, crop=false]]
-```
+## Documentation
 
-**Parameters:**
-
-- `page=` - Specify which pages to overlay (same format as INSERT)
-- `crop=` - Control content cropping:
-  - `crop=true` (default): Auto-crop to remove whitespace
-  - `crop=false`: Use full page dimensions
-
-#### 3. IMAGE Placeholders (Direct Image Insertion)
-
-Use `IMAGE` placeholders to insert image files directly into Word documents. Place these inside single-cell tables:
-
-```text
-[[IMAGE: photos/diagram.png]]
-[[IMAGE: charts/graph.jpg, width=3in]]
-[[IMAGE: icons/logo.png, width=2in, height=1in]]
-```
-
-**Supported formats:** PNG, JPG, JPEG, GIF, BMP, TIFF, WEBP
-
-**Parameters:**
-
-- `width=` - Set image width (e.g., `width=2in`, `width=100px`)
-- `height=` - Set image height (e.g., `height=1.5in`, `height=200px`)
-- If no dimensions specified: Auto-fits to table size while maintaining aspect ratio
-- If only width or height specified: Maintains aspect ratio
-
-#### Path Resolution
-
-All paths are resolved relative to your Word document's location:
-
-```text
-# If your Word document is in C:\Reports\
-[[INSERT: appendices/data.pdf]]        → C:\Reports\appendices\data.pdf
-[[OVERLAY: ..\shared\drawing.pdf]]     → C:\shared\drawing.pdf
-[[IMAGE: images/chart.png]]            → C:\Reports\images\chart.png
-[[INSERT: C:\absolute\path\file.pdf]]  → C:\absolute\path\file.pdf
-```
-
-### Word Integration Buttons
-
-If you installed the Word template, you'll have these ribbon buttons:
-
-- **Insert Appendix** - Adds an INSERT placeholder with file browser
-- **Insert Overlay** - Adds an OVERLAY placeholder in a table with options
-- **PDF to SVG** - Converts PDF pages to SVG for direct insertion
-- **Compile Report** - Runs the compiler directly from Word
-
-### Example Workflow
-
-1. **Create your report structure** in Word with regular text and formatting
-2. **Add placeholders** where you want PDF content:
-   - Use tables with OVERLAY placeholders for positioned content
-   - Use paragraphs with INSERT placeholders for full-page appendices
-3. **Save your document** (required for relative path resolution)
-4. **Run the compiler** from command line or Word button
-5. **Get your final PDF** with all content integrated seamlessly
-
-## Troubleshooting
-
-### Common Issues
-
-#### "Document must be saved first"
-
-- Save your Word document before compilation to enable relative path resolution
-
-#### "PDF file not found"
-
-- Check that PDF paths are correct relative to your Word document's location
-- Use the Word integration buttons for automatic relative path creation
-
-#### "Word automation failed"
-
-- Ensure Microsoft Word is installed and can be opened
-- Close any open Word documents that might interfere
-
-#### "Page selection invalid"
-
-- Check page numbers exist in the source PDF
-- Use 1-based page numbering (first page = 1)
-
-### Debug Mode
-
-Enable debug mode to troubleshoot issues:
-
-```bash
-report-compiler compile report.docx output.pdf --keep-temp --verbose
-```
-
-This will:
-
-- Keep all temporary files for inspection
-- Show detailed processing logs
-- Help identify where issues occur
-
-## System Requirements
-
-- **Windows** (for Word automation)
-- **Microsoft Word** installed
-- **Python 3.7+**
+- [WORD_INTEGRATION.md](WORD_INTEGRATION.md) — detailed Word setup, the ribbon, and how the template is built
+- [DEVELOPER_GUIDE.md](DEVELOPER_GUIDE.md) — architecture and contributing
 
 ## License
 
-This project is licensed under the MIT License.
+MIT — see [LICENSE](LICENSE).

--- a/docs/images/README.md
+++ b/docs/images/README.md
@@ -1,0 +1,3 @@
+# Screenshots
+
+Drop the screenshots referenced by the main README here (see the checklist in the PR / chat).

--- a/docs/superpowers/specs/2026-06-24-in-document-overlay-preview-design.md
+++ b/docs/superpowers/specs/2026-06-24-in-document-overlay-preview-design.md
@@ -1,0 +1,78 @@
+# In-Document Overlay Preview — Design
+
+## Context
+
+**Problem:** An OVERLAY placeholder is an empty 1×1 table cell holding a `[[OVERLAY: file.pdf, page=…]]` tag until compile. Coworkers can't tell *which* pages an overlay will insert or *how* they'll look, and can't see how the rest of the document reflows around multi-page overlays.
+
+**Goal:** Let users flip the whole document between **Tags**, a lightweight **Quick preview**, and a reflow-accurate **Full preview** of every overlay — rendered from the real PDFs, crop-accurate — without ever endangering a full-resolution compile.
+
+This is feature #3 of the GUI roadmap. It builds on the existing foundation: the COM server, `gui/pdf_render` (PyMuPDF raster), `content_analyzer` (cropping), `placeholder_parser`/`Config` (OVERLAY regex), and the Python-drives-Word pattern.
+
+**Decisions locked in:**
+- Document-wide **ribbon dropdown**: Tags / Quick / Full.
+- **Quick** = first selected page + `+N` badge (cell stays 1×1). **Full** = expand into per-page rows so surrounding content reflows.
+- Previews are **crop-accurate** (reuse `content_analyzer`).
+- **Recovery is a property of the compiler**, not just the toggle (see below).
+- Safeguards: redundant tag stored in each preview image's AltText; a **Repair overlays** command. (No strip-on-save, no save-blocking.)
+
+## Recovery & fidelity (the core guarantee)
+
+Preview images are **low-res throwaways**; the compiler ignores them entirely — it reads the tag, resolves the original PDF, and renders it vector-accurate via `show_pdf_page`. So previews can never reduce output quality; they only bloat the file while shown.
+
+The `[[OVERLAY: …]]` tag is always preserved as **hidden text** in the cell (survives save/reopen; still present in `cell.text`), and **redundantly** in each preview image's AltText. Canonical state of an overlay is a **1×1 single-cell borderless table** whose cell text matches the OVERLAY regex.
+
+**Compile-pipeline normalization (mandatory, covers every compile path — CLI, COM, button):** before parsing, the compiler normalizes overlays on its working copy so a saved-in-preview document always compiles correctly:
+- remove inline images marked `RCPREVIEW`,
+- collapse any expanded multi-row overlay table back to the single tagged row,
+- (hidden tag text is read fine by the parser, so no unhide needed for compile).
+
+Without this, a saved Full-preview overlay (multi-row table) would be **silently skipped** by the parser (it only treats 1×1 tables as overlays) and quick-preview images would leak into output. Normalization makes recovery guaranteed regardless of who compiles or how.
+
+## Architecture / flow
+
+```
+Ribbon dropdown "Overlay view"  (Tags | Quick | Full)   [VBA thin callback]
+  └ localDocPath = GetLocalPath(ActiveDocument.FullName)
+  └ CreateObject("ReportCompiler.Application").SetOverlayPreview(localDocPath, mode)
+
+COM server  SetOverlayPreview(doc_path, mode)
+  └ document/overlay_preview.set_overlay_view(doc_path, mode)
+       GetActiveObject("Word.Application") → restore-then-apply (idempotent):
+         1. restore_to_tags(doc): delete RCPREVIEW shapes, collapse rows to the tagged row, unhide tag
+         2. if mode == quick: per overlay → render first page → insert image + "+N" caption, hide tag
+            if mode == full:  per overlay → render each selected page → replicate rows + images, hide tag
+
+Compile (any path) → docx_processor normalizes overlays first (python-docx) → parse → render from source PDFs
+"Repair overlays" ribbon button → SetOverlayPreview(doc, "tags")  (force canonical)
+```
+
+Word stays the source of truth for the live preview; the operation runs synchronously in the COM call (typical docs have a handful of overlays). If it proves slow on large jobs, it can move to the async job+poll pattern later.
+
+## Components
+
+- **`utils/pdf_render.py`** (move from `gui/`): `page_count`, `render_page_png(pdf, page_index, target_width_px, clip=None)` — add optional `clip` rect for crop-accurate rendering. `gui/pdf_render` keeps only the `QPixmap` wrapper, importing from here (so non-GUI code no longer imports the GUI package).
+- **`document/overlay_preview.py`** (new): the live-Word engine — `set_overlay_view(doc_path, mode)`, `restore_to_tags(doc)`, `apply_quick(doc, …)`, `apply_full(doc, …)`, `iter_overlay_tables(doc)`. Uses win32com (`GetActiveObject`), the OVERLAY regex + `PageSelector` (page expansion) + `content_analyzer` (crop rect → clip). Marks inserted shapes with AltText = the tag, prefixed by the `RCPREVIEW` marker.
+- **`document/docx_processor.py`**: add `_normalize_overlay_previews(doc)` (python-docx) run at the start of processing — removes `RCPREVIEW` `<w:drawing>` runs and collapses multi-row overlay tables to the tagged row. Reuse the existing OVERLAY regex.
+- **`core/config.py`**: add `OVERLAY_PREVIEW_MARKER = "RCPREVIEW"` so the live engine and the compile normalizer agree on the marker.
+- **`com_server.py`**: `SetOverlayPreview(doc_path, mode)` added to `_public_methods_`.
+- **VBA `ReportingTools.bas` + `report_compiler_UI.xml`**: the "Overlay view" dropdown (Tags/Quick/Full) + a "Repair overlays" button; rebuild the `.dotm`. `RunReportCompiler` keeps working since normalization now lives in the pipeline (the button no longer needs its own strip, though it may still set Tags first for a clean visual).
+
+## Crop fidelity
+For each page, compute the crop rect with `content_analyzer.apply_content_cropping(page, crop_enabled)` and pass it as `clip` to `render_page_png`, so the preview matches what the compiler would overlay.
+
+## Error handling
+- Missing PDF / invalid page spec: the cell shows a red `⚠ missing: file.pdf` note but keeps the tag; the toggle continues and reports `rendered X overlays, Y errors`.
+- COM server not registered: the standard "COM Server Not Registered" message (mirrors the other buttons).
+- Restore is defensive: an overlay is any single-column table with a cell whose text matches the OVERLAY regex; the row carrying the tag is kept, others deleted.
+
+## Out of scope
+- Editing overlay parameters from preview (that's the overlay dialog / future link manager).
+- Per-overlay (non-document-wide) toggling.
+- Strip-on-save and save-blocking (explicitly declined).
+- Previews for IMAGE/INSERT placeholders (overlay-only for now).
+
+## Verification
+1. **Unit (no Word):** tag parse → (file, pages, crop); `PageSelector` expansion; `render_page_png` with a `clip` produces a valid cropped PNG; `docx_processor._normalize_overlay_previews` on a hand-built docx (multi-row table with `RCPREVIEW` images) collapses to a 1×1 with the tag intact.
+2. **Compile recovery (no live Word):** build a docx in the expanded/preview state (multi-row + marked images + hidden tag), run a normal `compile`, and confirm the overlay renders from the source PDF at full resolution and the preview images don't appear in output.
+3. **End-to-end in Word (real machine):** doc with 2 overlays → cycle Tags→Quick→Full→Tags and confirm a clean round-trip (cell text restored, no leftover rows/images); save while in Full preview, reopen, run **Repair overlays**, compile → correct high-res output.
+4. **Caveat:** the live-Word apply/restore (COM `GetActiveObject` manipulation) can't run in the agent sandbox — same registry/COM isolation as before; verified on a real interactive Windows session. The pure logic and the compile-time normalization are fully testable headless.

--- a/docs/superpowers/specs/2026-06-24-link-manager-design.md
+++ b/docs/superpowers/specs/2026-06-24-link-manager-design.md
@@ -1,0 +1,68 @@
+# Link Manager — Design
+
+## Context
+
+**Problem:** A report references external files through placeholders scattered across the document — overlays, appendices (`INSERT` PDFs), images, and recursive DOCX inserts. Today there's no way to see them all at once or know which paths are still valid; a broken link only surfaces as a compile error. Engineers expect an xref-style window (AutoCAD) / link manager (Revit): one list of every link, its validity, and quick actions to fix it.
+
+**Goal:** A PySide6 window, launched from the ribbon, that scans the **live** Word document via COM, lists every link with its validity, and offers per-link **Go to**, **Open file**, **Relink**, and a **Relative ⇄ Absolute** path toggle.
+
+This is the final GUI-roadmap feature. It reuses the foundation already built: the COM server + launch pattern, the PySide6 shell, the live-doc COM iteration in `overlay_preview.py`, the placeholder regexes in `Config`, and `Validators`.
+
+**Decisions locked in:**
+- Scan the **live Word doc via COM** (reflects unsaved edits; enables navigation), not the saved file.
+- Actions: **Go to**, **Open file**, **Relink** (fix/move path). No bulk operations.
+- **Per-link Relative ⇄ Absolute toggle** (rewrites the tag's path form; the common direction is →absolute). No bulk convert.
+- **Skip preview-freshness** — v1 shows path validity only.
+
+## Architecture / flow
+
+```
+Ribbon "Link manager"  (VBA thin launcher)
+  └ localDocPath = GetLocalPath(ActiveDocument.FullName)
+  └ CreateObject("ReportCompiler.Application").LaunchLinkManager(localDocPath)
+
+COM server  LaunchLinkManager(doc_path)
+  └ subprocess.Popen([sys.executable, "-m", "report_compiler.gui", "link-manager", "--doc", doc_path])
+
+GUI process (PySide6)
+  ├ GetActiveObject("Word.Application") → find document
+  ├ scan_links(doc, doc_path) → [LinkRecord]   (validity via Validators)
+  ├ table view + detail panel (both path forms)
+  └ actions operate on the live doc via COM:
+       Go to    → record.locator.Select() + ActiveWindow.ScrollIntoView + Word.Activate
+       Open     → os.startfile(resolved_path)
+       Relink   → file dialog → rewrite tag's file (preserve params) → re-validate
+       Rel/Abs  → rewrite tag's file to the other form → re-validate
+```
+
+Same model as the overlay dialog: the GUI runs in its own process and reads/writes the live document through COM.
+
+## Components
+
+- **`document/link_index.py`** — the scanner (win32com):
+  - `scan_links(doc, doc_path) -> list[LinkRecord]`: iterate `doc.Tables` (cells matching `OVERLAY_REGEX` / `IMAGE_REGEX`) and `doc.Paragraphs` (text matching `INSERT_REGEX`; `.docx` target ⇒ recursive-docx kind). Mirrors the live iteration already in [overlay_preview.py](src/report_compiler/document/overlay_preview.py).
+  - `LinkRecord`: `kind` (overlay/image/appendix/docx), `raw_tag`, `stored_path`, `is_absolute`, `relative_form`, `absolute_form`, `pages`, `page_count`, `status`, `message`, `locator` (the Word `Range`/table for navigation).
+  - `classify(kind, stored_path, doc_dir) -> (status, resolved_path, page_count, message)` — **pure, testable**, delegating to `Validators.validate_pdf_path` / `validate_image_path` / `validate_docx_path` ([utils/validators.py](src/report_compiler/utils/validators.py)). Statuses: `ok`, `missing`, `wrong_type`, `page_out_of_range` (warning).
+  - `rewrite_link_path(record, new_path)` — replace only the file portion (regex group 1) inside `raw_tag`, preserving all params, and write it back into the cell/paragraph via COM. Used by both Relink and the Rel/Abs toggle. For an overlay currently showing a preview, restore it to tags first (reuse `overlay_preview` restore).
+- **`gui/link_manager_dialog.py`** — `QTableView` (Type · Link · Pages · Status badge) above a **detail panel** showing the selected link's relative and absolute paths, page info, the Rel/Abs segmented toggle, and the action buttons. Double-click a row = Go to. A **Refresh** re-scans.
+- **`com_server.LaunchLinkManager(doc_path)`**; ribbon button + thin VBA launcher (mirrors `InsertOverlayPlaceholder`).
+
+## Path forms (Relative ⇄ Absolute)
+Both forms are always computed for display: `absolute_form = abspath(join(doc_dir, stored))` (or `stored` if already absolute); `relative_form = relpath(absolute_form, doc_dir)` with forward slashes. The toggle rewrites the stored path to the chosen form. **Absolute→Relative is disabled when the file is on a different drive** than the document (no relative path exists). "Absolute" is the resolved **local** path (the launcher passes the OneDrive/SharePoint-resolved doc path).
+
+## Error handling
+- COM server not registered → the standard "COM Server Not Registered" message.
+- Document never saved → relative resolution has no base; show a notice and still list links (absolute-only).
+- A link whose tag can't be parsed → listed as `kind=unknown`, status `wrong_type`, never silently dropped.
+- Relink/convert failures surface per-row without aborting the others; Refresh always re-syncs from the live doc.
+
+## Out of scope
+- Bulk convert-all and bulk relink.
+- Preview-freshness / refresh-preview (deferred).
+- Editing page ranges or crop from the manager (that's the overlay dialog).
+- IMAGE/INSERT to non-file targets.
+
+## Verification
+1. **Unit (no Word):** `classify` over a temp dir — ok / missing / wrong_type / page_out_of_range for PDF, image, and DOCX targets; `relative_form`/`absolute_form` computation incl. the cross-drive guard; `rewrite_link_path` swaps the file and preserves params (`page=`, `crop=`, `:1-3`) for all tag types.
+2. **End-to-end in Word (real machine):** open a doc with overlays/appendices/images/DOCX inserts (some broken) → list shows correct statuses; Go to scrolls to the link; Open launches the file; Relink fixes a broken path; the Rel/Abs toggle rewrites the tag and the row re-validates; Refresh picks up external edits.
+3. **Caveat:** the live COM scan / navigation / write-back can't run in the agent sandbox (same registry/COM isolation as the other Word features); verified on a real interactive session. `classify`, path-form computation, and `rewrite_link_path` string logic are fully testable headless.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "typer>=0.9.0",
     "pywin32; sys_platform == 'win32'",
     "questionary>=2.0.1",
+    "PySide6>=6.6",
 ]
 
 [project.scripts]

--- a/src/report_compiler/com_server.py
+++ b/src/report_compiler/com_server.py
@@ -167,6 +167,7 @@ class ReportCompilerCOMServer:
         "CompileAsync",
         "SvgImportAsync",
         "LaunchOverlayDialog",
+        "SetOverlayPreview",
         "GetJobStatus",
         "GetJobMessage",
     ]
@@ -222,6 +223,16 @@ class ReportCompilerCOMServer:
             close_fds=True,
         )
         return "launched"
+
+    def SetOverlayPreview(self, doc_path, mode):
+        """Switch the document's overlay view: 'tags', 'quick', or 'full'.
+
+        Runs synchronously (manipulates the live document) and returns a short summary.
+        Errors are raised to the COM client.
+        """
+        from report_compiler.document import overlay_preview
+
+        return overlay_preview.set_overlay_view(str(doc_path), str(mode))
 
     def GetJobStatus(self, job_id):
         job = _JOBS.get(str(job_id))

--- a/src/report_compiler/com_server.py
+++ b/src/report_compiler/com_server.py
@@ -167,6 +167,7 @@ class ReportCompilerCOMServer:
         "CompileAsync",
         "SvgImportAsync",
         "LaunchOverlayDialog",
+        "LaunchLinkManager",
         "SetOverlayPreview",
         "GetJobStatus",
         "GetJobMessage",
@@ -220,6 +221,14 @@ class ReportCompilerCOMServer:
                 "--anchor",
                 str(anchor),
             ],
+            close_fds=True,
+        )
+        return "launched"
+
+    def LaunchLinkManager(self, doc_path):
+        """Spawn the Link Manager GUI as its own process and return immediately."""
+        subprocess.Popen(
+            [sys.executable, "-m", "report_compiler.gui", "link-manager", "--doc", str(doc_path)],
             close_fds=True,
         )
         return "launched"

--- a/src/report_compiler/com_server.py
+++ b/src/report_compiler/com_server.py
@@ -163,7 +163,13 @@ class ReportCompilerCOMServer:
     polls :meth:`GetJobStatus` / :meth:`GetJobMessage`.
     """
 
-    _public_methods_ = ["CompileAsync", "SvgImportAsync", "GetJobStatus", "GetJobMessage"]
+    _public_methods_ = [
+        "CompileAsync",
+        "SvgImportAsync",
+        "LaunchOverlayDialog",
+        "GetJobStatus",
+        "GetJobMessage",
+    ]
     _reg_clsid_ = CLSID
     _reg_progid_ = PROGID
     _reg_desc_ = DESC
@@ -194,6 +200,28 @@ class ReportCompilerCOMServer:
         )
         thread.start()
         return job_id
+
+    def LaunchOverlayDialog(self, doc_path, anchor):
+        """Spawn the Insert PDF Overlay GUI as its own process and return immediately.
+
+        Not part of the async-job model — this just launches a UI process, which then
+        attaches to Word itself to write back. Uses this interpreter (the stable tool
+        env) so PySide6 and the package are available.
+        """
+        subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "report_compiler.gui",
+                "overlay",
+                "--doc",
+                str(doc_path),
+                "--anchor",
+                str(anchor),
+            ],
+            close_fds=True,
+        )
+        return "launched"
 
     def GetJobStatus(self, job_id):
         job = _JOBS.get(str(job_id))

--- a/src/report_compiler/core/compiler.py
+++ b/src/report_compiler/core/compiler.py
@@ -215,6 +215,15 @@ class ReportCompiler:
             return False
         
         try:
+            # Collapse any in-document overlay previews (expanded rows + preview images)
+            # back to canonical tags first, so a doc saved mid-preview still compiles.
+            normalized = self.docx_processor.normalize_overlay_previews(self.temp_docx_path)
+            if normalized:
+                self.logger.info(f"{self._log_prefix()}  > Normalized {normalized} overlay preview(s) back to tags.")
+        except Exception as e:
+            self.logger.warning(f"{self._log_prefix()}  > Overlay preview normalization skipped: {e}")
+
+        try:
             self.placeholders = self.placeholder_parser.find_all_placeholders(self.temp_docx_path)
             if self.placeholders['total'] == 0:
                 self.logger.info(f"{self._log_prefix()}  > No placeholders found.")

--- a/src/report_compiler/core/config.py
+++ b/src/report_compiler/core/config.py
@@ -21,7 +21,7 @@ class Config:
     
     # PDF processing defaults
     DEFAULT_PADDING = 32  # points
-    DEFAULT_CROP_ENABLED = True
+    DEFAULT_CROP_ENABLED = False
     
     # File handling
     TEMP_FILE_PREFIX = "~temp_"

--- a/src/report_compiler/core/config.py
+++ b/src/report_compiler/core/config.py
@@ -22,6 +22,10 @@ class Config:
     # PDF processing defaults
     DEFAULT_PADDING = 32  # points
     DEFAULT_CROP_ENABLED = False
+
+    # Marker stored in the AltText of in-document overlay-preview images so they can be
+    # found and stripped again (by the live toggle and the compile-time normalizer).
+    OVERLAY_PREVIEW_MARKER = "RCPREVIEW"
     
     # File handling
     TEMP_FILE_PREFIX = "~temp_"

--- a/src/report_compiler/document/docx_processor.py
+++ b/src/report_compiler/document/docx_processor.py
@@ -6,6 +6,7 @@ import os
 from typing import Dict, List, Optional
 from docx import Document
 from docx.shared import Inches
+from docx.oxml.ns import qn
 from PIL import Image
 from ..core.config import Config
 from ..utils.logging_config import get_docx_logger
@@ -18,6 +19,88 @@ class DocxProcessor:
 
     def __init__(self):
         self.logger = get_docx_logger()
+
+    # --- In-document overlay-preview normalization ---------------------------
+    # The in-document preview feature can leave a saved docx with overlay tables
+    # expanded into multiple rows and filled with low-res preview images. Those would
+    # break compilation (the parser only treats 1x1 tables as overlays, and the images
+    # would leak into output). This collapses every overlay table back to its canonical
+    # 1x1 tag form so any compile path recovers a clean, full-resolution result.
+
+    def normalize_overlay_previews(self, docx_path: str) -> int:
+        """Collapse in-document overlay previews back to canonical tag tables, in place.
+
+        Returns the number of overlay tables that were normalized.
+        """
+        doc = Document(docx_path)
+        count = 0
+        for table in doc.tables:
+            if not self._is_single_column(table):
+                continue
+            tag = self._overlay_tag_of_table(table)
+            if tag is None:
+                continue
+            self._remove_preview_images(table)
+            self._collapse_overlay_table(table, tag)
+            count += 1
+        if count:
+            doc.save(docx_path)
+        return count
+
+    @staticmethod
+    def _is_single_column(table) -> bool:
+        try:
+            return len(table.rows) >= 1 and all(len(row.cells) == 1 for row in table.rows)
+        except Exception:
+            return False
+
+    def _overlay_tag_of_table(self, table) -> Optional[str]:
+        """Return the overlay tag for this table, or None if it isn't an overlay.
+
+        Prefers the tag from a cell's text (hidden text still appears in .text); falls
+        back to the redundant copy stored in a preview image's AltText.
+        """
+        for row in table.rows:
+            match = Config.OVERLAY_REGEX.search(row.cells[0].text)
+            if match:
+                return match.group(0)
+        return self._tag_from_preview_image(table)
+
+    def _tag_from_preview_image(self, table) -> Optional[str]:
+        marker = Config.OVERLAY_PREVIEW_MARKER
+        for docpr in table._tbl.iter(qn("wp:docPr")):
+            descr = docpr.get("descr") or ""
+            if descr.startswith(marker):
+                tag = descr[len(marker):].lstrip(":").strip()
+                if Config.OVERLAY_REGEX.search(tag):
+                    return Config.OVERLAY_REGEX.search(tag).group(0)
+        return None
+
+    def _remove_preview_images(self, table) -> None:
+        """Delete runs holding a preview image (identified by the marker in AltText)."""
+        marker = Config.OVERLAY_PREVIEW_MARKER
+        for docpr in list(table._tbl.iter(qn("wp:docPr"))):
+            if not (docpr.get("descr") or "").startswith(marker):
+                continue
+            run = docpr
+            while run is not None and run.tag != qn("w:r"):
+                run = run.getparent()
+            if run is not None and run.getparent() is not None:
+                run.getparent().remove(run)
+
+    def _collapse_overlay_table(self, table, tag: str) -> None:
+        """Keep only the tag-bearing row and set its cell to the plain tag text."""
+        tbl = table._tbl
+        rows = table.rows
+        keep_idx = 0
+        for i, row in enumerate(rows):
+            if Config.OVERLAY_REGEX.search(row.cells[0].text):
+                keep_idx = i
+                break
+        for i, tr in enumerate(tbl.findall(qn("w:tr"))):
+            if i != keep_idx:
+                tbl.remove(tr)
+        table.rows[0].cells[0].text = tag
 
     def create_modified_docx(
         self, input_path: str, placeholders: Dict[str, List[Dict]], output_path: str

--- a/src/report_compiler/document/link_index.py
+++ b/src/report_compiler/document/link_index.py
@@ -1,0 +1,277 @@
+"""Enumerate and classify the links (placeholders) in the live Word document.
+
+Powers the link manager. Scanning and navigation/rewrite touch Word via COM, but the
+classification and tag-rewrite logic are pure functions so they can be unit-tested
+without Word.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Optional
+
+try:
+    import win32com.client  # noqa: F401  (presence check; COM used via passed objects)
+except ImportError:  # pragma: no cover - non-Windows
+    win32com = None
+
+from ..core.config import Config
+from ..gui.overlay_logic import parse_overlay_tag
+from ..utils.page_selector import PageSelector
+from ..utils.validators import Validators
+
+# Statuses
+OK = "ok"
+MISSING = "missing"
+WRONG_TYPE = "wrong_type"
+PAGE_RANGE = "page_out_of_range"
+UNKNOWN = "unknown"
+
+# Kinds
+OVERLAY = "overlay"
+IMAGE = "image"
+APPENDIX = "appendix"
+DOCX = "docx"
+
+_REGEX_FOR_KIND = {
+    OVERLAY: Config.OVERLAY_REGEX,
+    IMAGE: Config.IMAGE_REGEX,
+    APPENDIX: Config.INSERT_REGEX,
+    DOCX: Config.INSERT_REGEX,
+}
+
+_selector = PageSelector()
+
+
+# --- pure logic (testable) ----------------------------------------------------
+def resolve_forms(stored_path: str, doc_dir: str):
+    """Return (absolute_form, relative_form). relative_form is None when no relative
+    path exists (no doc dir, or a different drive)."""
+    if os.path.isabs(stored_path):
+        absolute = os.path.normpath(stored_path)
+    elif doc_dir:
+        absolute = os.path.normpath(os.path.join(doc_dir, stored_path))
+    else:
+        absolute = stored_path
+    relative = None
+    if doc_dir:
+        try:
+            relative = os.path.relpath(absolute, doc_dir).replace(os.sep, "/")
+        except ValueError:
+            relative = None  # different drive
+    return absolute, relative
+
+
+def _max_requested_page(page_spec: Optional[str]) -> Optional[int]:
+    """Highest explicit 1-based page in a spec, or None (open ranges/all are unbounded)."""
+    if not page_spec:
+        return None
+    sel = _selector.parse_specification(page_spec)
+    if sel["use_all"] or not sel["pages"]:
+        return None
+    return max(sel["pages"]) + 1
+
+
+def classify(kind: str, stored_path: str, page_spec: Optional[str], doc_dir: str) -> dict:
+    """Resolve and validate a link. Pure: filesystem + Validators only, no Word."""
+    absolute, relative = resolve_forms(stored_path, doc_dir)
+    out = {
+        "resolved_path": absolute,
+        "absolute_form": absolute,
+        "relative_form": relative,
+        "page_count": 0,
+        "status": UNKNOWN,
+        "message": "",
+    }
+    if kind in (OVERLAY, APPENDIX):
+        result = Validators.validate_pdf_path(absolute, "")
+    elif kind == IMAGE:
+        result = Validators.validate_image_path(absolute, "")
+    elif kind == DOCX:
+        result = Validators.validate_docx_path(absolute)
+    else:
+        out["message"] = "Unrecognized link"
+        return out
+
+    out["page_count"] = result.get("page_count", 0)
+    if not result["valid"]:
+        error = result.get("error_message") or "Invalid file"
+        out["status"] = MISSING if "not found" in error.lower() else WRONG_TYPE
+        out["message"] = error
+        return out
+
+    if kind in (OVERLAY, APPENDIX):
+        max_page = _max_requested_page(page_spec)
+        if max_page and out["page_count"] and max_page > out["page_count"]:
+            out["status"] = PAGE_RANGE
+            out["message"] = f"Requested page {max_page} exceeds {out['page_count']} pages"
+            return out
+
+    out["status"] = OK
+    return out
+
+
+def rewrite_tag_file(raw_tag: str, kind: str, new_path: str) -> str:
+    """Return raw_tag with only its file path (regex group 1) replaced — params kept."""
+    regex = _REGEX_FOR_KIND.get(kind)
+    match = regex.search(raw_tag) if regex else None
+    if not match:
+        return raw_tag
+    start, end = match.start(1), match.end(1)
+    return raw_tag[:start] + new_path + raw_tag[end:]
+
+
+# --- link record --------------------------------------------------------------
+@dataclass
+class LinkRecord:
+    kind: str
+    raw_tag: str
+    stored_path: str
+    page_spec: Optional[str]
+    status: str
+    message: str
+    resolved_path: str
+    relative_form: Optional[str]
+    absolute_form: str
+    page_count: int
+    is_absolute: bool
+    locator: object = field(default=None, repr=False)
+
+
+# --- COM locators (navigate / rewrite the live doc) ---------------------------
+class _TableLocator:
+    """Overlay/image link living in a 1x1 table cell."""
+
+    def __init__(self, table):
+        self.table = table
+
+    def select(self):
+        self.table.Range.Select()
+
+    def set_tag(self, new_tag, old_tag=None):
+        table = self.table
+        for shape in list(table.Range.InlineShapes):  # drop any preview images
+            try:
+                shape.Delete()
+            except Exception:
+                pass
+        while table.Rows.Count > 1:  # collapse any full-preview expansion
+            table.Rows(table.Rows.Count).Delete()
+        cell = table.Cell(1, 1)
+        cell.Range.Text = new_tag
+        cell.Range.Font.Hidden = False
+
+
+class _ParagraphLocator:
+    """INSERT/appendix/docx link living in a paragraph."""
+
+    def __init__(self, rng):
+        self.range = rng
+
+    def select(self):
+        self.range.Select()
+
+    def set_tag(self, new_tag, old_tag=None):
+        find = self.range.Find
+        find.ClearFormatting()
+        find.Replacement.ClearFormatting()
+        find.MatchWildcards = False
+        find.Text = old_tag
+        find.Replacement.Text = new_tag
+        find.Execute(Replace=1)  # wdReplaceOne
+
+
+# --- scanning the live document ----------------------------------------------
+def find_document(word, doc_path: str):
+    target = os.path.normcase(os.path.abspath(doc_path))
+    for doc in word.Documents:
+        try:
+            if os.path.normcase(os.path.abspath(doc.FullName)) == target:
+                return doc
+        except Exception:
+            continue
+    return word.ActiveDocument
+
+
+def _make_record(kind, raw_tag, stored_path, page_spec, doc_dir, locator) -> LinkRecord:
+    info = classify(kind, stored_path, page_spec, doc_dir)
+    return LinkRecord(
+        kind=kind,
+        raw_tag=raw_tag,
+        stored_path=stored_path,
+        page_spec=page_spec,
+        status=info["status"],
+        message=info["message"],
+        resolved_path=info["resolved_path"],
+        relative_form=info["relative_form"],
+        absolute_form=info["absolute_form"],
+        page_count=info["page_count"],
+        is_absolute=os.path.isabs(stored_path),
+        locator=locator,
+    )
+
+
+def scan_links(doc, doc_path: str) -> list:
+    """Scan the live document for every link. Returns a list of LinkRecord."""
+    doc_dir = os.path.dirname(doc_path)
+    records: list = []
+
+    for table in doc.Tables:
+        try:
+            cell_text = table.Cell(1, 1).Range.Text
+        except Exception:
+            continue
+        overlay = Config.OVERLAY_REGEX.search(cell_text)
+        if overlay:
+            parsed = parse_overlay_tag(overlay.group(0)) or {}
+            records.append(_make_record(
+                OVERLAY, overlay.group(0), parsed.get("file", ""), parsed.get("page"),
+                doc_dir, _TableLocator(table)))
+            continue
+        image = Config.IMAGE_REGEX.search(cell_text)
+        if image:
+            records.append(_make_record(
+                IMAGE, image.group(0), image.group(1).strip(), None,
+                doc_dir, _TableLocator(table)))
+
+    for paragraph in doc.Paragraphs:
+        try:
+            text = paragraph.Range.Text
+        except Exception:
+            continue
+        insert = Config.INSERT_REGEX.search(text)
+        if insert:
+            path = insert.group(1).strip()
+            page_spec = (insert.group(2) or "").strip() or None
+            kind = DOCX if path.lower().endswith(".docx") else APPENDIX
+            records.append(_make_record(
+                kind, insert.group(0), path, page_spec, doc_dir,
+                _ParagraphLocator(paragraph.Range)))
+
+    return records
+
+
+# --- actions ------------------------------------------------------------------
+def go_to(word, record: LinkRecord) -> None:
+    if record.locator is not None:
+        record.locator.select()
+    try:
+        word.Activate()
+    except Exception:
+        pass
+
+
+def open_source(record: LinkRecord) -> bool:
+    if record.resolved_path and os.path.isfile(record.resolved_path):
+        os.startfile(record.resolved_path)  # noqa: S606 - opening the user's own linked file
+        return True
+    return False
+
+
+def set_link_path(record: LinkRecord, new_stored_path: str, doc_dir: str) -> LinkRecord:
+    """Rewrite the tag's file to new_stored_path (params preserved) and re-classify."""
+    new_tag = rewrite_tag_file(record.raw_tag, record.kind, new_stored_path)
+    if record.locator is not None:
+        record.locator.set_tag(new_tag, record.raw_tag)
+    return _make_record(record.kind, new_tag, new_stored_path, record.page_spec, doc_dir, record.locator)

--- a/src/report_compiler/document/overlay_preview.py
+++ b/src/report_compiler/document/overlay_preview.py
@@ -56,6 +56,7 @@ def set_overlay_view(doc_path: str, mode: str) -> str:
         _restore_table(table)
 
     if mode == "tags":
+        _refresh(word)
         return f"Overlay view: tags ({len(overlays)} overlay(s))."
 
     rendered, errors = 0, 0
@@ -72,9 +73,22 @@ def set_overlay_view(doc_path: str, mode: str) -> str:
     finally:
         shutil.rmtree(tmp_dir, ignore_errors=True)
 
+    _refresh(word)
     msg = f"Overlay view: {mode} ({rendered} overlay(s)"
     msg += f", {errors} error(s))" if errors else ")"
     return msg
+
+
+def _refresh(word) -> None:
+    """Force the live Word window to repaint after cross-process edits."""
+    try:
+        word.ScreenUpdating = True
+    except Exception:
+        pass
+    try:
+        word.ScreenRefresh()
+    except Exception:
+        pass
 
 
 # --- document / table helpers -------------------------------------------------
@@ -122,10 +136,19 @@ def _tag_of_table(table):
 def _restore_table(table) -> None:
     """Collapse to a single row and set the cell to the plain, visible tag."""
     tag = _tag_of_table(table) or ""
+    # Explicitly delete the preview images (overlay tables hold only our previews).
+    try:
+        for shape in list(table.Range.InlineShapes):
+            try:
+                shape.Delete()
+            except Exception:
+                pass
+    except Exception:
+        pass
     while table.Rows.Count > 1:
         table.Rows(table.Rows.Count).Delete()
     cell = table.Cell(1, 1)
-    cell.Range.Text = tag  # replaces text and removes any inline images
+    cell.Range.Text = tag  # replaces remaining text content
     cell.Range.Font.Hidden = False
 
 
@@ -238,7 +261,14 @@ def _mark_error(table, message: str) -> None:
 
 
 def _column_width(table):
-    try:
-        return table.Columns(1).Width
-    except Exception:
-        return None
+    """A sane image width in points. Word reports wdUndefined (a huge sentinel) for
+    autofit tables, which would make the picture overflow the cell — so clamp and fall
+    back to a reasonable default."""
+    for getter in (lambda: table.Columns(1).Width, lambda: table.Cell(1, 1).Width):
+        try:
+            width = getter()
+            if width and 0 < width < 1000:
+                return width
+        except Exception:
+            pass
+    return 400.0  # ~5.5 inches

--- a/src/report_compiler/document/overlay_preview.py
+++ b/src/report_compiler/document/overlay_preview.py
@@ -85,10 +85,7 @@ def set_overlay_view(doc_path: str, mode: str) -> str:
     finally:
         _set_cursor(word, _WD_CURSOR_NORMAL)
         _refresh(word)
-        try:
-            word.StatusBar = False  # hand the status bar back to Word
-        except Exception:
-            pass
+        _clear_status(word)
 
 
 def _status(word, message: str) -> None:
@@ -106,6 +103,23 @@ def _status(word, message: str) -> None:
 def _set_cursor(word, cursor) -> None:
     try:
         word.System.Cursor = cursor
+    except Exception:
+        pass
+
+
+def _clear_status(word) -> None:
+    """Relinquish the status bar back to Word. Setting the Python bool False marshals as
+    the text 'False' over COM, so pass a real VT_BOOL (falling back to an empty string)."""
+    try:
+        import pythoncom
+        from win32com.client import VARIANT
+
+        word.StatusBar = VARIANT(pythoncom.VT_BOOL, False)
+        return
+    except Exception:
+        pass
+    try:
+        word.StatusBar = ""
     except Exception:
         pass
 

--- a/src/report_compiler/document/overlay_preview.py
+++ b/src/report_compiler/document/overlay_preview.py
@@ -1,0 +1,231 @@
+"""In-document overlay preview: render OVERLAY pages into the live Word doc via COM.
+
+Driven from the COM server (``SetOverlayPreview``). Three modes:
+  - ``tags``  : restore every overlay to its canonical 1x1 tag table.
+  - ``quick`` : first selected page in the cell + a "+N more" caption.
+  - ``full``  : expand into one row per selected page so surrounding content reflows.
+
+The ``[[OVERLAY: …]]`` tag is always preserved as hidden text in the cell (and redundantly
+in each preview image's AltText), so the document still compiles at full resolution. The
+compile pipeline independently normalizes any leftover previews (see
+``DocxProcessor.normalize_overlay_previews``), so recovery never depends on this toggle.
+
+This module drives Word and can only be exercised on a real interactive session.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+
+import fitz  # PyMuPDF
+
+try:
+    import win32com.client
+except ImportError:  # pragma: no cover - non-Windows
+    win32com = None
+
+from ..core.config import Config
+from ..gui.overlay_logic import expand_selection, format_spec, parse_overlay_tag
+from ..pdf.content_analyzer import ContentAnalyzer
+from ..utils.logging_config import get_logger
+from ..utils.pdf_render import page_count
+
+_MARKER = Config.OVERLAY_PREVIEW_MARKER
+_WD_COLLAPSE_END = 0
+_WD_COLOR_RED = 255
+_QUICK_WIDTH_PX = 600
+_FULL_WIDTH_PX = 800
+
+
+def set_overlay_view(doc_path: str, mode: str) -> str:
+    """Apply ``mode`` ('tags' | 'quick' | 'full') to every overlay in the document."""
+    if win32com is None:
+        raise RuntimeError("pywin32 is not installed; cannot reach Word.")
+    if mode not in ("tags", "quick", "full"):
+        raise ValueError(f"Unknown overlay view mode: {mode}")
+
+    logger = get_logger()
+    word = win32com.client.GetActiveObject("Word.Application")
+    doc = _find_document(word, doc_path)
+
+    overlays = [t for t in doc.Tables if _is_overlay_table(t)]
+    # Restore-then-apply: every switch starts from canonical tags (idempotent).
+    for table in overlays:
+        _restore_table(table)
+
+    if mode == "tags":
+        return f"Overlay view: tags ({len(overlays)} overlay(s))."
+
+    rendered, errors = 0, 0
+    tmp_dir = tempfile.mkdtemp(prefix="rc_ovlprev_")
+    try:
+        for table in overlays:
+            try:
+                _apply_table(table, mode, doc_path, tmp_dir)
+                rendered += 1
+            except Exception as exc:  # noqa: BLE001 - one bad overlay shouldn't abort the rest
+                errors += 1
+                logger.warning("Overlay preview failed: %s", exc)
+                _mark_error(table, str(exc))
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    msg = f"Overlay view: {mode} ({rendered} overlay(s)"
+    msg += f", {errors} error(s))" if errors else ")"
+    return msg
+
+
+# --- document / table helpers -------------------------------------------------
+def _find_document(word, doc_path: str):
+    target = os.path.normcase(os.path.abspath(doc_path))
+    for doc in word.Documents:
+        try:
+            if os.path.normcase(os.path.abspath(doc.FullName)) == target:
+                return doc
+        except Exception:
+            continue
+    return word.ActiveDocument
+
+
+def _is_overlay_table(table) -> bool:
+    try:
+        if table.Columns.Count != 1:
+            return False
+    except Exception:
+        return False
+    return _tag_of_table(table) is not None
+
+
+def _tag_of_table(table):
+    """Tag string for an overlay table, from cell text (hidden ok) or image AltText."""
+    try:
+        for r in range(1, table.Rows.Count + 1):
+            match = Config.OVERLAY_REGEX.search(table.Cell(r, 1).Range.Text)
+            if match:
+                return match.group(0)
+    except Exception:
+        pass
+    try:
+        for shape in table.Range.InlineShapes:
+            descr = shape.AlternativeText or ""
+            if descr.startswith(_MARKER):
+                match = Config.OVERLAY_REGEX.search(descr)
+                if match:
+                    return match.group(0)
+    except Exception:
+        pass
+    return None
+
+
+def _restore_table(table) -> None:
+    """Collapse to a single row and set the cell to the plain, visible tag."""
+    tag = _tag_of_table(table) or ""
+    while table.Rows.Count > 1:
+        table.Rows(table.Rows.Count).Delete()
+    cell = table.Cell(1, 1)
+    cell.Range.Text = tag  # replaces text and removes any inline images
+    cell.Range.Font.Hidden = False
+
+
+# --- applying previews --------------------------------------------------------
+def _apply_table(table, mode: str, doc_path: str, tmp_dir: str) -> None:
+    tag = _tag_of_table(table)
+    parsed = parse_overlay_tag(tag)
+    if parsed is None:
+        raise ValueError("not an overlay tag")
+
+    pdf_path = os.path.abspath(os.path.join(os.path.dirname(doc_path), parsed["file"]))
+    if not os.path.isfile(pdf_path):
+        raise FileNotFoundError(f"missing: {parsed['file']}")
+
+    total = page_count(pdf_path)
+    indices = sorted(expand_selection(parsed["page"] or "", total)) or [0]
+    col_width = _column_width(table)
+
+    if mode == "quick":
+        pngs = _render_pages(pdf_path, indices[:1], parsed["crop"], tmp_dir, _QUICK_WIDTH_PX)
+        cell = table.Cell(1, 1)
+        _set_hidden_tag(cell, tag)
+        _insert_image(cell, pngs[0], tag, col_width)
+        caption = f"{os.path.basename(parsed['file'])} · p.{format_spec(set(indices))}"
+        if len(indices) > 1:
+            caption += f"  (+{len(indices) - 1} more)"
+        _append_caption(cell, caption)
+    else:  # full
+        pngs = _render_pages(pdf_path, indices, parsed["crop"], tmp_dir, _FULL_WIDTH_PX)
+        cell = table.Cell(1, 1)
+        _set_hidden_tag(cell, tag)
+        _insert_image(cell, pngs[0], tag, col_width)
+        for png in pngs[1:]:
+            table.Rows.Add()
+            new_cell = table.Cell(table.Rows.Count, 1)
+            new_cell.Range.Text = ""
+            _insert_image(new_cell, png, tag, col_width)
+
+
+def _render_pages(pdf_path, indices, crop, tmp_dir, width_px):
+    """Render selected pages to temp PNGs, applying the same crop the compiler would."""
+    analyzer = ContentAnalyzer()
+    out = []
+    with fitz.open(pdf_path) as doc:
+        for i in indices:
+            page = doc[i]
+            clip = analyzer.apply_content_cropping(page, crop)
+            zoom = width_px / clip.width if clip.width else 1.0
+            pix = page.get_pixmap(matrix=fitz.Matrix(zoom, zoom), clip=clip, alpha=False)
+            path = os.path.join(tmp_dir, f"ovl_{i}.png")
+            pix.save(path)
+            out.append(path)
+    return out
+
+
+def _set_hidden_tag(cell, tag: str) -> None:
+    cell.Range.Text = tag
+    cell.Range.Font.Hidden = True
+
+
+def _insert_image(cell, png_path: str, tag: str, col_width) -> None:
+    rng = cell.Range
+    rng.Collapse(_WD_COLLAPSE_END)
+    shape = rng.InlineShapes.AddPicture(FileName=png_path, LinkToFile=False, SaveWithDocument=True)
+    try:
+        shape.LockAspectRatio = -1  # msoTrue
+        if col_width:
+            shape.Width = col_width
+    except Exception:
+        pass
+    try:
+        shape.AlternativeText = f"{_MARKER}:{tag}"
+    except Exception:
+        pass
+
+
+def _append_caption(cell, text: str) -> None:
+    rng = cell.Range
+    rng.Collapse(_WD_COLLAPSE_END)
+    rng.Text = "\r" + text
+    rng.Font.Hidden = False
+
+
+def _mark_error(table, message: str) -> None:
+    """Show a red warning in the cell while keeping the tag (hidden) for recovery."""
+    try:
+        tag = _tag_of_table(table) or ""
+        cell = table.Cell(1, 1)
+        _set_hidden_tag(cell, tag)
+        rng = cell.Range
+        rng.Collapse(_WD_COLLAPSE_END)
+        rng.Text = "\r⚠ " + message
+        rng.Font.Hidden = False
+        rng.Font.Color = _WD_COLOR_RED
+    except Exception:
+        pass
+
+
+def _column_width(table):
+    try:
+        return table.Columns(1).Width
+    except Exception:
+        return None

--- a/src/report_compiler/document/overlay_preview.py
+++ b/src/report_compiler/document/overlay_preview.py
@@ -212,17 +212,32 @@ def _reset_cell(cell) -> None:
     cell.Range.Font.Hidden = False
 
 
-def _append_hidden_tag(cell, tag: str) -> None:
-    """Append the tag at the end of the cell and hide only that run (kept for compile)."""
+def _inside_end(cell):
+    """A collapsed range just *inside* the cell, before its end-of-cell marker.
+
+    A cell's Range ends at the cell marker; collapsing to that end and inserting there
+    spills content past the marker, which in the last cell of a row creates a brand-new
+    cell (column). Stepping back one character keeps inserts inside the cell.
+    """
     rng = cell.Range
+    try:
+        if rng.End - 1 >= rng.Start:
+            rng.End = rng.End - 1
+    except Exception:
+        pass
     rng.Collapse(_WD_COLLAPSE_END)
+    return rng
+
+
+def _append_hidden_tag(cell, tag: str) -> None:
+    """Append the tag inside the cell and hide only that run (kept for compile)."""
+    rng = _inside_end(cell)
     rng.Text = tag
     rng.Font.Hidden = True
 
 
 def _insert_image(cell, png_path: str, tag: str, col_width) -> None:
-    rng = cell.Range
-    rng.Collapse(_WD_COLLAPSE_END)
+    rng = _inside_end(cell)
     rng.Font.Hidden = False  # ensure the picture's run is not hidden-formatted
     shape = rng.InlineShapes.AddPicture(FileName=png_path, LinkToFile=False, SaveWithDocument=True)
     try:
@@ -238,8 +253,7 @@ def _insert_image(cell, png_path: str, tag: str, col_width) -> None:
 
 
 def _append_caption(cell, text: str) -> None:
-    rng = cell.Range
-    rng.Collapse(_WD_COLLAPSE_END)
+    rng = _inside_end(cell)
     rng.Text = "\r" + text
     rng.Font.Hidden = False
 
@@ -250,8 +264,7 @@ def _mark_error(table, message: str) -> None:
         tag = _tag_of_table(table) or ""
         cell = table.Cell(1, 1)
         _reset_cell(cell)
-        rng = cell.Range
-        rng.Collapse(_WD_COLLAPSE_END)
+        rng = _inside_end(cell)
         rng.Text = "⚠ " + message
         rng.Font.Hidden = False
         rng.Font.Color = _WD_COLOR_RED

--- a/src/report_compiler/document/overlay_preview.py
+++ b/src/report_compiler/document/overlay_preview.py
@@ -35,6 +35,8 @@ from ..utils.pdf_render import page_count
 _MARKER = Config.OVERLAY_PREVIEW_MARKER
 _WD_COLLAPSE_END = 0
 _WD_COLOR_RED = 255
+_WD_CURSOR_WAIT = 0  # WdCursorType: wait
+_WD_CURSOR_NORMAL = 2  # WdCursorType: normal
 _QUICK_WIDTH_PX = 600
 _FULL_WIDTH_PX = 800
 
@@ -51,32 +53,61 @@ def set_overlay_view(doc_path: str, mode: str) -> str:
     doc = _find_document(word, doc_path)
 
     overlays = [t for t in doc.Tables if _is_overlay_table(t)]
-    # Restore-then-apply: every switch starts from canonical tags (idempotent).
-    for table in overlays:
-        _restore_table(table)
-
-    if mode == "tags":
-        _refresh(word)
-        return f"Overlay view: tags ({len(overlays)} overlay(s))."
-
-    rendered, errors = 0, 0
-    tmp_dir = tempfile.mkdtemp(prefix="rc_ovlprev_")
+    total = len(overlays)
+    _set_cursor(word, _WD_CURSOR_WAIT)
     try:
-        for table in overlays:
-            try:
-                _apply_table(table, mode, doc_path, tmp_dir)
-                rendered += 1
-            except Exception as exc:  # noqa: BLE001 - one bad overlay shouldn't abort the rest
-                errors += 1
-                logger.warning("Overlay preview failed: %s", exc)
-                _mark_error(table, str(exc))
-    finally:
-        shutil.rmtree(tmp_dir, ignore_errors=True)
+        # Restore-then-apply: every switch starts from canonical tags (idempotent).
+        for i, table in enumerate(overlays, 1):
+            _status(word, f"Report Compiler: resetting overlay {i} of {total}…")
+            _restore_table(table)
 
-    _refresh(word)
-    msg = f"Overlay view: {mode} ({rendered} overlay(s)"
-    msg += f", {errors} error(s))" if errors else ")"
-    return msg
+        if mode == "tags":
+            return f"Overlay view: tags ({total} overlay(s))."
+
+        rendered, errors = 0, 0
+        tmp_dir = tempfile.mkdtemp(prefix="rc_ovlprev_")
+        try:
+            for i, table in enumerate(overlays, 1):
+                _status(word, f"Report Compiler: rendering overlay {i} of {total} ({mode})…")
+                try:
+                    _apply_table(table, mode, doc_path, tmp_dir)
+                    rendered += 1
+                except Exception as exc:  # noqa: BLE001 - one bad overlay shouldn't abort the rest
+                    errors += 1
+                    logger.warning("Overlay preview failed: %s", exc)
+                    _mark_error(table, str(exc))
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+        msg = f"Overlay view: {mode} ({rendered} overlay(s)"
+        msg += f", {errors} error(s))" if errors else ")"
+        return msg
+    finally:
+        _set_cursor(word, _WD_CURSOR_NORMAL)
+        _refresh(word)
+        try:
+            word.StatusBar = False  # hand the status bar back to Word
+        except Exception:
+            pass
+
+
+def _status(word, message: str) -> None:
+    """Show progress in Word's status bar and repaint so it's visible mid-operation."""
+    try:
+        word.StatusBar = message
+    except Exception:
+        pass
+    try:
+        word.ScreenRefresh()
+    except Exception:
+        pass
+
+
+def _set_cursor(word, cursor) -> None:
+    try:
+        word.System.Cursor = cursor
+    except Exception:
+        pass
 
 
 def _refresh(word) -> None:

--- a/src/report_compiler/document/overlay_preview.py
+++ b/src/report_compiler/document/overlay_preview.py
@@ -147,8 +147,9 @@ def _apply_table(table, mode: str, doc_path: str, tmp_dir: str) -> None:
     if mode == "quick":
         pngs = _render_pages(pdf_path, indices[:1], parsed["crop"], tmp_dir, _QUICK_WIDTH_PX)
         cell = table.Cell(1, 1)
-        _set_hidden_tag(cell, tag)
+        _reset_cell(cell)
         _insert_image(cell, pngs[0], tag, col_width)
+        _append_hidden_tag(cell, tag)
         caption = f"{os.path.basename(parsed['file'])} · p.{format_spec(set(indices))}"
         if len(indices) > 1:
             caption += f"  (+{len(indices) - 1} more)"
@@ -156,12 +157,13 @@ def _apply_table(table, mode: str, doc_path: str, tmp_dir: str) -> None:
     else:  # full
         pngs = _render_pages(pdf_path, indices, parsed["crop"], tmp_dir, _FULL_WIDTH_PX)
         cell = table.Cell(1, 1)
-        _set_hidden_tag(cell, tag)
+        _reset_cell(cell)
         _insert_image(cell, pngs[0], tag, col_width)
+        _append_hidden_tag(cell, tag)
         for png in pngs[1:]:
             table.Rows.Add()
             new_cell = table.Cell(table.Rows.Count, 1)
-            new_cell.Range.Text = ""
+            _reset_cell(new_cell)
             _insert_image(new_cell, png, tag, col_width)
 
 
@@ -181,14 +183,24 @@ def _render_pages(pdf_path, indices, crop, tmp_dir, width_px):
     return out
 
 
-def _set_hidden_tag(cell, tag: str) -> None:
-    cell.Range.Text = tag
-    cell.Range.Font.Hidden = True
+def _reset_cell(cell) -> None:
+    """Empty a cell and clear hidden formatting so inserted images stay visible."""
+    cell.Range.Text = ""
+    cell.Range.Font.Hidden = False
+
+
+def _append_hidden_tag(cell, tag: str) -> None:
+    """Append the tag at the end of the cell and hide only that run (kept for compile)."""
+    rng = cell.Range
+    rng.Collapse(_WD_COLLAPSE_END)
+    rng.Text = tag
+    rng.Font.Hidden = True
 
 
 def _insert_image(cell, png_path: str, tag: str, col_width) -> None:
     rng = cell.Range
     rng.Collapse(_WD_COLLAPSE_END)
+    rng.Font.Hidden = False  # ensure the picture's run is not hidden-formatted
     shape = rng.InlineShapes.AddPicture(FileName=png_path, LinkToFile=False, SaveWithDocument=True)
     try:
         shape.LockAspectRatio = -1  # msoTrue
@@ -214,12 +226,13 @@ def _mark_error(table, message: str) -> None:
     try:
         tag = _tag_of_table(table) or ""
         cell = table.Cell(1, 1)
-        _set_hidden_tag(cell, tag)
+        _reset_cell(cell)
         rng = cell.Range
         rng.Collapse(_WD_COLLAPSE_END)
-        rng.Text = "\r⚠ " + message
+        rng.Text = "⚠ " + message
         rng.Font.Hidden = False
         rng.Font.Color = _WD_COLOR_RED
+        _append_hidden_tag(cell, tag)
     except Exception:
         pass
 

--- a/src/report_compiler/gui/__init__.py
+++ b/src/report_compiler/gui/__init__.py
@@ -1,0 +1,6 @@
+"""PySide6 GUI dialogs for the Word integration (driven from the COM server).
+
+The dialogs run as their own process (launched by the COM server) and attach to the
+live Word instance via COM to write back. Pure, Qt-free logic lives in
+``overlay_logic`` so it can be unit-tested without PySide6 or Word.
+"""

--- a/src/report_compiler/gui/__main__.py
+++ b/src/report_compiler/gui/__main__.py
@@ -18,6 +18,9 @@ def main(argv: list[str] | None = None) -> int:
     overlay.add_argument("--doc", default="", help="Local path of the active Word document")
     overlay.add_argument("--anchor", default="", help="Bookmark name to insert at")
 
+    links = sub.add_parser("link-manager", help="Link manager window")
+    links.add_argument("--doc", default="", help="Local path of the active Word document")
+
     args = parser.parse_args(argv)
 
     if args.command == "overlay":
@@ -26,6 +29,15 @@ def main(argv: list[str] | None = None) -> int:
 
         app = QApplication(sys.argv)
         dialog = OverlayDialog(doc_path=args.doc, anchor=args.anchor)
+        dialog.show()
+        return app.exec()
+
+    if args.command == "link-manager":
+        from PySide6.QtWidgets import QApplication
+        from report_compiler.gui.link_manager_dialog import LinkManagerDialog
+
+        app = QApplication(sys.argv)
+        dialog = LinkManagerDialog(doc_path=args.doc)
         dialog.show()
         return app.exec()
 

--- a/src/report_compiler/gui/__main__.py
+++ b/src/report_compiler/gui/__main__.py
@@ -1,0 +1,37 @@
+"""Entry point for GUI dialogs: ``python -m report_compiler.gui <command> [opts]``.
+
+Launched by the COM server (e.g. ``LaunchOverlayDialog``) as its own process, or run
+manually for development.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="report_compiler.gui")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    overlay = sub.add_parser("overlay", help="Insert PDF overlay dialog")
+    overlay.add_argument("--doc", default="", help="Local path of the active Word document")
+    overlay.add_argument("--anchor", default="", help="Bookmark name to insert at")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "overlay":
+        from PySide6.QtWidgets import QApplication
+        from report_compiler.gui.overlay_dialog import OverlayDialog
+
+        app = QApplication(sys.argv)
+        dialog = OverlayDialog(doc_path=args.doc, anchor=args.anchor)
+        dialog.show()
+        return app.exec()
+
+    parser.error(f"unknown command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/report_compiler/gui/link_manager_dialog.py
+++ b/src/report_compiler/gui/link_manager_dialog.py
@@ -1,0 +1,280 @@
+"""Link manager window (PySide6).
+
+Lists every link in the live Word document with its validity, and offers per-link
+Go to / Open file / Relink and a Relative <-> Absolute path toggle. Reads and writes the
+document through COM (``document.link_index``).
+"""
+
+from __future__ import annotations
+
+import os
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QColor
+from PySide6.QtWidgets import (
+    QButtonGroup,
+    QDialog,
+    QFileDialog,
+    QFrame,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QMessageBox,
+    QPushButton,
+    QRadioButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+)
+
+from report_compiler.document import link_index as li
+
+_KIND_LABEL = {li.OVERLAY: "Overlay", li.IMAGE: "Image", li.APPENDIX: "Appendix", li.DOCX: "DOCX"}
+_STATUS_LABEL = {
+    li.OK: "OK",
+    li.MISSING: "Missing",
+    li.WRONG_TYPE: "Wrong type",
+    li.PAGE_RANGE: "Page range",
+    li.UNKNOWN: "Unknown",
+}
+_STATUS_COLOR = {
+    li.OK: "#1D9E75",
+    li.MISSING: "#E24B4A",
+    li.WRONG_TYPE: "#E24B4A",
+    li.PAGE_RANGE: "#BA7517",
+    li.UNKNOWN: "#888780",
+}
+_FILE_FILTER = {
+    li.OVERLAY: "PDF files (*.pdf)",
+    li.APPENDIX: "PDF files (*.pdf)",
+    li.IMAGE: "Images (*.png *.jpg *.jpeg *.gif *.bmp *.tif *.tiff *.svg *.emf *.wmf)",
+    li.DOCX: "Word documents (*.docx)",
+}
+
+
+class LinkManagerDialog(QDialog):
+    def __init__(self, doc_path: str = "", parent=None):
+        super().__init__(parent)
+        self.setWindowTitle(f"Link manager — {os.path.basename(doc_path) or 'document'}")
+        self.resize(720, 560)
+        self._doc_path = doc_path
+        self._doc_dir = os.path.dirname(doc_path)
+        self._word = None
+        self._doc = None
+        self._records: list = []
+        self._updating = False
+
+        root = QVBoxLayout(self)
+
+        # Toolbar
+        bar = QHBoxLayout()
+        bar.addStretch(1)
+        refresh = QPushButton("Refresh")
+        refresh.clicked.connect(self._refresh)
+        bar.addWidget(refresh)
+        root.addLayout(bar)
+
+        # Table
+        self._table = QTableWidget(0, 4)
+        self._table.setHorizontalHeaderLabels(["Type", "Link", "Pages", "Status"])
+        self._table.verticalHeader().setVisible(False)
+        self._table.setSelectionBehavior(QTableWidget.SelectRows)
+        self._table.setSelectionMode(QTableWidget.SingleSelection)
+        self._table.setEditTriggers(QTableWidget.NoEditTriggers)
+        header = self._table.horizontalHeader()
+        header.setSectionResizeMode(0, QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(1, QHeaderView.Stretch)
+        header.setSectionResizeMode(2, QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(3, QHeaderView.ResizeToContents)
+        self._table.itemSelectionChanged.connect(self._on_selection)
+        self._table.itemDoubleClicked.connect(lambda *_: self._go_to())
+        root.addWidget(self._table, 1)
+
+        root.addWidget(self._build_detail_panel())
+
+        self._summary = QLabel("")
+        self._summary.setStyleSheet("color: #5F5E5A;")
+        root.addWidget(self._summary)
+
+        self._connect_word()
+        self._refresh()
+
+    # --- detail panel --------------------------------------------------------
+    def _build_detail_panel(self) -> QFrame:
+        panel = QFrame()
+        panel.setFrameShape(QFrame.StyledPanel)
+        layout = QVBoxLayout(panel)
+
+        self._title_label = QLabel("Select a link")
+        self._title_label.setStyleSheet("font-weight: 500;")
+        layout.addWidget(self._title_label)
+
+        self._rel_label = QLabel("")
+        self._abs_label = QLabel("")
+        for lbl in (self._rel_label, self._abs_label):
+            lbl.setTextInteractionFlags(Qt.TextSelectableByMouse)
+            layout.addWidget(lbl)
+
+        store = QHBoxLayout()
+        store.addWidget(QLabel("Store path as"))
+        self._rel_radio = QRadioButton("Relative")
+        self._abs_radio = QRadioButton("Absolute")
+        self._form_group = QButtonGroup(self)
+        self._form_group.addButton(self._rel_radio)
+        self._form_group.addButton(self._abs_radio)
+        self._rel_radio.toggled.connect(self._on_form_toggled)
+        store.addWidget(self._rel_radio)
+        store.addWidget(self._abs_radio)
+        store.addStretch(1)
+        layout.addLayout(store)
+
+        actions = QHBoxLayout()
+        self._goto_btn = QPushButton("Go to")
+        self._goto_btn.clicked.connect(self._go_to)
+        self._open_btn = QPushButton("Open file")
+        self._open_btn.clicked.connect(self._open_file)
+        self._relink_btn = QPushButton("Relink…")
+        self._relink_btn.clicked.connect(self._relink)
+        actions.addWidget(self._goto_btn)
+        actions.addWidget(self._open_btn)
+        actions.addWidget(self._relink_btn)
+        actions.addStretch(1)
+        layout.addLayout(actions)
+
+        self._set_detail_enabled(False)
+        return panel
+
+    # --- Word + scan ---------------------------------------------------------
+    def _connect_word(self) -> None:
+        try:
+            import win32com.client
+
+            self._word = win32com.client.GetActiveObject("Word.Application")
+            self._doc = li.find_document(self._word, self._doc_path)
+        except Exception as exc:
+            QMessageBox.warning(self, "Word not found", f"Could not attach to Word:\n{exc}")
+
+    def _refresh(self) -> None:
+        if self._doc is None:
+            return
+        try:
+            self._records = li.scan_links(self._doc, self._doc_path)
+        except Exception as exc:
+            QMessageBox.critical(self, "Scan failed", str(exc))
+            return
+        self._populate()
+
+    def _populate(self) -> None:
+        self._table.setRowCount(len(self._records))
+        for row, rec in enumerate(self._records):
+            self._set_row(row, rec)
+        missing = sum(1 for r in self._records if r.status in (li.MISSING, li.WRONG_TYPE))
+        warns = sum(1 for r in self._records if r.status == li.PAGE_RANGE)
+        parts = [f"{len(self._records)} links"]
+        if missing:
+            parts.append(f"{missing} broken")
+        if warns:
+            parts.append(f"{warns} warning")
+        self._summary.setText("  ·  ".join(parts))
+        self._set_detail_enabled(False)
+        self._title_label.setText("Select a link")
+
+    def _set_row(self, row: int, rec) -> None:
+        pages = rec.page_spec or ("all" if rec.kind in (li.OVERLAY, li.APPENDIX) else "—")
+        cells = [_KIND_LABEL.get(rec.kind, rec.kind), rec.stored_path, pages, _STATUS_LABEL.get(rec.status, rec.status)]
+        for col, text in enumerate(cells):
+            item = QTableWidgetItem(text)
+            if col == 3:
+                item.setForeground(QColor(_STATUS_COLOR.get(rec.status, "#888780")))
+                if rec.message:
+                    item.setToolTip(rec.message)
+            self._table.setItem(row, col, item)
+
+    # --- selection + detail --------------------------------------------------
+    def _current_row(self) -> int:
+        rows = self._table.selectionModel().selectedRows()
+        return rows[0].row() if rows else -1
+
+    def _on_selection(self) -> None:
+        row = self._current_row()
+        if row < 0 or row >= len(self._records):
+            self._set_detail_enabled(False)
+            return
+        rec = self._records[row]
+        self._title_label.setText(f"{_KIND_LABEL.get(rec.kind, rec.kind)} · {os.path.basename(rec.stored_path)}")
+        self._rel_label.setText(f"Relative:  {rec.relative_form or '(unavailable — different drive)'}")
+        self._abs_label.setText(f"Absolute:  {rec.absolute_form}")
+        self._set_detail_enabled(True)
+        self._updating = True
+        self._abs_radio.setChecked(rec.is_absolute)
+        self._rel_radio.setChecked(not rec.is_absolute)
+        self._rel_radio.setEnabled(rec.relative_form is not None)
+        self._updating = False
+        self._open_btn.setEnabled(rec.status in (li.OK, li.PAGE_RANGE))
+
+    def _set_detail_enabled(self, enabled: bool) -> None:
+        for w in (self._goto_btn, self._open_btn, self._relink_btn, self._rel_radio, self._abs_radio):
+            w.setEnabled(enabled)
+        if not enabled:
+            self._rel_label.setText("")
+            self._abs_label.setText("")
+
+    # --- actions -------------------------------------------------------------
+    def _go_to(self) -> None:
+        rec = self._selected()
+        if rec:
+            try:
+                li.go_to(self._word, rec)
+            except Exception as exc:
+                QMessageBox.warning(self, "Go to failed", str(exc))
+
+    def _open_file(self) -> None:
+        rec = self._selected()
+        if rec and not li.open_source(rec):
+            QMessageBox.information(self, "File not found", f"Cannot open:\n{rec.absolute_form}")
+
+    def _relink(self) -> None:
+        rec = self._selected()
+        if not rec:
+            return
+        start = os.path.dirname(rec.absolute_form) if rec.absolute_form else self._doc_dir
+        path, _ = QFileDialog.getOpenFileName(self, "Relink to file", start, _FILE_FILTER.get(rec.kind, "All files (*.*)"))
+        if not path:
+            return
+        # Preserve the link's current path form (relative unless it was absolute / cross-drive).
+        new_stored = path
+        if not rec.is_absolute:
+            try:
+                new_stored = os.path.relpath(path, self._doc_dir).replace(os.sep, "/")
+            except ValueError:
+                new_stored = path
+        self._apply_new_path(rec, new_stored)
+
+    def _on_form_toggled(self) -> None:
+        if self._updating:
+            return
+        rec = self._selected()
+        if not rec:
+            return
+        want_absolute = self._abs_radio.isChecked()
+        if want_absolute == rec.is_absolute:
+            return
+        new_stored = rec.absolute_form if want_absolute else rec.relative_form
+        if not new_stored:
+            return
+        self._apply_new_path(rec, new_stored)
+
+    def _apply_new_path(self, rec, new_stored: str) -> None:
+        row = self._current_row()
+        try:
+            new_rec = li.set_link_path(rec, new_stored, self._doc_dir)
+        except Exception as exc:
+            QMessageBox.critical(self, "Update failed", str(exc))
+            return
+        self._records[row] = new_rec
+        self._set_row(row, new_rec)
+        self._on_selection()
+
+    def _selected(self):
+        row = self._current_row()
+        return self._records[row] if 0 <= row < len(self._records) else None

--- a/src/report_compiler/gui/overlay_dialog.py
+++ b/src/report_compiler/gui/overlay_dialog.py
@@ -1,0 +1,288 @@
+"""The Insert PDF Overlay dialog (PySide6).
+
+Grid of page thumbnails with the selected pages highlighted, two-way synced with a
+page-range box. On Insert it builds the [[OVERLAY: ...]] tag and writes it back into the
+live Word document via ``word_writer``.
+"""
+
+from __future__ import annotations
+
+import os
+
+from PySide6.QtCore import QObject, Qt, QThread, Signal, Slot
+from PySide6.QtGui import QPixmap
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QDialog,
+    QFileDialog,
+    QFrame,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
+
+from report_compiler.gui import pdf_render, word_writer
+from report_compiler.gui.overlay_logic import (
+    build_overlay_tag,
+    expand_selection,
+    format_spec,
+    relative_pdf_path,
+)
+
+_THUMB_W = 120
+_COLS = 4
+_SEL_STYLE = "border: 2px solid #378ADD; border-radius: 6px; background: #E6F1FB;"
+_UNSEL_STYLE = "border: 1px solid #C9C9C4; border-radius: 6px; background: white;"
+
+
+class _ThumbWorker(QObject):
+    """Renders page PNGs off the UI thread; emits bytes per page."""
+
+    rendered = Signal(int, bytes)
+    done = Signal()
+
+    def __init__(self, pdf_path: str, count: int, width: int):
+        super().__init__()
+        self._pdf_path = pdf_path
+        self._count = count
+        self._width = width
+
+    @Slot()
+    def run(self) -> None:
+        for i in range(self._count):
+            try:
+                png = pdf_render.render_page_png(self._pdf_path, i, self._width)
+            except Exception:
+                png = b""
+            self.rendered.emit(i, png)
+        self.done.emit()
+
+
+class _PageThumb(QFrame):
+    """One clickable page thumbnail; click toggles selection."""
+
+    clicked = Signal(int)
+
+    def __init__(self, index: int):
+        super().__init__()
+        self._index = index
+        self.setFixedWidth(_THUMB_W + 16)
+        self.setStyleSheet(_UNSEL_STYLE)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(6, 6, 6, 6)
+        self._image = QLabel("…")
+        self._image.setAlignment(Qt.AlignCenter)
+        self._image.setMinimumHeight(int(_THUMB_W / 0.77))
+        self._number = QLabel(str(index + 1))
+        self._number.setAlignment(Qt.AlignCenter)
+        self._number.setStyleSheet("border: none; color: #5F5E5A; font-size: 11px;")
+        layout.addWidget(self._image)
+        layout.addWidget(self._number)
+
+    def set_pixmap(self, pixmap: QPixmap) -> None:
+        self._image.setPixmap(pixmap.scaledToWidth(_THUMB_W, Qt.SmoothTransformation))
+
+    def set_selected(self, selected: bool) -> None:
+        self.setStyleSheet(_SEL_STYLE if selected else _UNSEL_STYLE)
+
+    def mousePressEvent(self, event) -> None:  # noqa: N802 (Qt override)
+        self.clicked.emit(self._index)
+
+
+class OverlayDialog(QDialog):
+    def __init__(self, doc_path: str = "", anchor: str = "", parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Insert PDF overlay")
+        self.resize(620, 640)
+        self._doc_path = doc_path
+        self._anchor = anchor
+        self._pdf_path = ""
+        self._total = 0
+        self._selected: set[int] = set()
+        self._thumbs: list[_PageThumb] = []
+        self._syncing = False
+        self._thread: QThread | None = None
+
+        root = QVBoxLayout(self)
+
+        # PDF file row
+        file_row = QHBoxLayout()
+        file_row.addWidget(QLabel("PDF file"))
+        self._path_edit = QLineEdit()
+        self._path_edit.setReadOnly(True)
+        file_row.addWidget(self._path_edit, 1)
+        browse = QPushButton("Browse…")
+        browse.clicked.connect(self._on_browse)
+        file_row.addWidget(browse)
+        root.addLayout(file_row)
+
+        # Selection toolbar (select/deselect all + live count)
+        sel_bar = QHBoxLayout()
+        self._select_all_btn = QPushButton("Select all")
+        self._select_all_btn.clicked.connect(self._on_select_all)
+        self._deselect_all_btn = QPushButton("Deselect all")
+        self._deselect_all_btn.clicked.connect(self._on_deselect_all)
+        self._select_all_btn.setEnabled(False)
+        self._deselect_all_btn.setEnabled(False)
+        sel_bar.addWidget(self._select_all_btn)
+        sel_bar.addWidget(self._deselect_all_btn)
+        sel_bar.addStretch(1)
+        self._count_label = QLabel("")
+        self._count_label.setStyleSheet("color: #5F5E5A;")
+        sel_bar.addWidget(self._count_label)
+        root.addLayout(sel_bar)
+
+        # Thumbnail grid in a scroll area
+        self._grid_host = QWidget()
+        self._grid = QGridLayout(self._grid_host)
+        self._grid.setAlignment(Qt.AlignTop)
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setWidget(self._grid_host)
+        root.addWidget(scroll, 1)
+
+        # Page range + crop
+        opts = QHBoxLayout()
+        opts.addWidget(QLabel("Pages"))
+        self._pages_edit = QLineEdit()
+        self._pages_edit.setPlaceholderText("all  (e.g. 1-3, 5, 8-)")
+        self._pages_edit.textEdited.connect(self._on_pages_edited)
+        opts.addWidget(self._pages_edit, 1)
+        self._crop = QCheckBox("Auto-crop to content")
+        self._crop.setChecked(False)
+        opts.addWidget(self._crop)
+        root.addLayout(opts)
+
+        # Buttons
+        btns = QHBoxLayout()
+        btns.addStretch(1)
+        cancel = QPushButton("Cancel")
+        cancel.clicked.connect(self.reject)
+        btns.addWidget(cancel)
+        self._insert = QPushButton("Insert overlay")
+        self._insert.setDefault(True)
+        self._insert.setEnabled(False)
+        self._insert.clicked.connect(self._on_insert)
+        btns.addWidget(self._insert)
+        root.addLayout(btns)
+
+    # --- PDF loading ---------------------------------------------------------
+    def _on_browse(self) -> None:
+        start_dir = os.path.dirname(self._doc_path) if self._doc_path else ""
+        path, _ = QFileDialog.getOpenFileName(self, "Select a PDF", start_dir, "PDF files (*.pdf)")
+        if path:
+            self._load_pdf(path)
+
+    def _load_pdf(self, path: str) -> None:
+        try:
+            total = pdf_render.page_count(path)
+        except Exception as exc:
+            QMessageBox.critical(self, "Cannot open PDF", str(exc))
+            return
+        self._pdf_path = path
+        self._total = total
+        self._path_edit.setText(path)
+        self._build_grid()
+        # Default: all pages selected (empty box == all).
+        self._pages_edit.clear()
+        self._selected = set(range(total))
+        self._refresh_selection_styles()
+        self._insert.setEnabled(True)
+        self._select_all_btn.setEnabled(True)
+        self._deselect_all_btn.setEnabled(True)
+        self._start_render()
+
+    def _build_grid(self) -> None:
+        while self._grid.count():
+            item = self._grid.takeAt(0)
+            if item.widget():
+                item.widget().deleteLater()
+        self._thumbs = []
+        for i in range(self._total):
+            thumb = _PageThumb(i)
+            thumb.clicked.connect(self._on_thumb_clicked)
+            self._thumbs.append(thumb)
+            self._grid.addWidget(thumb, i // _COLS, i % _COLS)
+
+    def _start_render(self) -> None:
+        if self._thread is not None:
+            self._thread.quit()
+            self._thread.wait()
+        self._thread = QThread()
+        self._worker = _ThumbWorker(self._pdf_path, self._total, _THUMB_W * 2)
+        self._worker.moveToThread(self._thread)
+        self._thread.started.connect(self._worker.run)
+        self._worker.rendered.connect(self._on_thumb_rendered)
+        self._worker.done.connect(self._thread.quit)
+        self._thread.start()
+
+    @Slot(int, bytes)
+    def _on_thumb_rendered(self, index: int, png: bytes) -> None:
+        if png and 0 <= index < len(self._thumbs):
+            pixmap = QPixmap()
+            pixmap.loadFromData(png, "PNG")
+            self._thumbs[index].set_pixmap(pixmap)
+
+    # --- selection sync ------------------------------------------------------
+    def _on_pages_edited(self, text: str) -> None:
+        if self._syncing:
+            return
+        self._selected = expand_selection(text, self._total)
+        self._refresh_selection_styles()
+
+    def _on_thumb_clicked(self, index: int) -> None:
+        if index in self._selected:
+            self._selected.discard(index)
+        else:
+            self._selected.add(index)
+        self._sync_box_from_selection()
+        self._refresh_selection_styles()
+
+    def _on_select_all(self) -> None:
+        self._selected = set(range(self._total))
+        self._sync_box_from_selection()
+        self._refresh_selection_styles()
+
+    def _on_deselect_all(self) -> None:
+        self._selected = set()
+        self._sync_box_from_selection()
+        self._refresh_selection_styles()
+
+    def _sync_box_from_selection(self) -> None:
+        """Update the page-range box to match the current selection (no feedback loop)."""
+        self._syncing = True
+        self._pages_edit.setText(format_spec(self._selected))
+        self._syncing = False
+
+    def _refresh_selection_styles(self) -> None:
+        for i, thumb in enumerate(self._thumbs):
+            thumb.set_selected(i in self._selected)
+        self._count_label.setText(f"{len(self._selected)} of {self._total} pages selected")
+
+    # --- insert --------------------------------------------------------------
+    def _on_insert(self) -> None:
+        if not self._pdf_path:
+            return
+        if not self._selected:
+            QMessageBox.warning(self, "No pages", "Select at least one page to overlay.")
+            return
+        rel = relative_pdf_path(self._pdf_path, self._doc_path or self._pdf_path)
+        tag = build_overlay_tag(rel, self._selected, self._total, self._crop.isChecked())
+
+        if not self._doc_path:
+            # Standalone/dev mode (no Word attached): just echo the tag.
+            print(tag)
+            self.accept()
+            return
+        try:
+            word_writer.insert_overlay_table(self._doc_path, self._anchor, tag)
+        except Exception as exc:
+            QMessageBox.critical(self, "Insert failed", f"Could not insert into Word:\n{exc}")
+            return
+        self.accept()

--- a/src/report_compiler/gui/overlay_logic.py
+++ b/src/report_compiler/gui/overlay_logic.py
@@ -6,11 +6,37 @@ Kept separate from the PySide6 dialog so it can be unit-tested without a GUI or 
 from __future__ import annotations
 
 import os
-from typing import List, Set
+from typing import List, Optional, Set
 
+from report_compiler.core.config import Config
 from report_compiler.utils.page_selector import PageSelector
 
 _selector = PageSelector()
+
+
+def parse_overlay_tag(tag: str) -> Optional[dict]:
+    """Parse an ``[[OVERLAY: file, page=…, crop=…]]`` tag into its parts.
+
+    Returns ``{'file', 'page' (spec str or None), 'crop' (bool)}`` or None if not an
+    overlay tag. Mirrors the parameter handling in placeholder_parser.
+    """
+    match = Config.OVERLAY_REGEX.search(tag)
+    if not match:
+        return None
+    result = {"file": match.group(1).strip(), "page": None, "crop": Config.DEFAULT_CROP_ENABLED}
+    params = match.group(2)
+    if params:
+        for part in (p.strip() for p in params.split(",")):
+            if "=" in part:
+                key, value = part.split("=", 1)
+                key, value = key.strip().lower(), value.strip()
+                if key == "page":
+                    result["page"] = value
+                elif key == "crop":
+                    result["crop"] = value.lower() in ("true", "1", "yes", "on", "enabled")
+            elif part and result["page"] is None:
+                result["page"] = part
+    return result
 
 
 def expand_selection(spec: str, total_pages: int) -> Set[int]:

--- a/src/report_compiler/gui/overlay_logic.py
+++ b/src/report_compiler/gui/overlay_logic.py
@@ -1,0 +1,74 @@
+"""Qt-free logic for the overlay dialog: page expansion, tag building, relative paths.
+
+Kept separate from the PySide6 dialog so it can be unit-tested without a GUI or Word.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import List, Set
+
+from report_compiler.utils.page_selector import PageSelector
+
+_selector = PageSelector()
+
+
+def expand_selection(spec: str, total_pages: int) -> Set[int]:
+    """Resolve a page-spec string to a concrete set of 0-based page indices.
+
+    Reuses ``PageSelector.parse_specification`` and clamps to the document size.
+    Empty/blank spec means "all pages".
+    """
+    selection = _selector.parse_specification(spec)
+    if selection["use_all"]:
+        return set(range(total_pages))
+
+    pages: Set[int] = set(selection["pages"])
+    open_start = selection["open_range_start"]
+    if open_start is not None:
+        pages |= set(range(open_start, total_pages))
+    return {p for p in pages if 0 <= p < total_pages}
+
+
+def format_spec(pages_zero_based: Set[int]) -> str:
+    """Serialize a set of 0-based page indices to a compact 1-based spec ("1-3, 5")."""
+    if not pages_zero_based:
+        return ""
+    # PageSelector.format_page_list collapses runs into ranges; feed it 1-based pages.
+    one_based = sorted(p + 1 for p in pages_zero_based)
+    return _selector.format_page_list(one_based, one_based=True)
+
+
+def relative_pdf_path(pdf_path: str, doc_path: str) -> str:
+    """Path of ``pdf_path`` relative to the document's folder, using forward slashes.
+
+    Falls back to the absolute path when the two are on different drives (Windows),
+    where a relative path is impossible.
+    """
+    doc_dir = os.path.dirname(doc_path)
+    try:
+        rel = os.path.relpath(pdf_path, doc_dir)
+    except ValueError:
+        rel = os.path.abspath(pdf_path)
+    return rel.replace(os.sep, "/")
+
+
+def build_overlay_tag(
+    rel_path: str,
+    selected_pages_zero_based: Set[int],
+    total_pages: int,
+    crop: bool,
+) -> str:
+    """Build an ``[[OVERLAY: ...]]`` tag.
+
+    Omits ``page=`` when every page is selected (the parser treats absent page as all).
+    Cropping defaults to off, so only the on case is written (``crop=true``); when off we
+    omit ``crop=`` entirely to keep the tag clean.
+    """
+    tag = f"[[OVERLAY: {rel_path}"
+    if selected_pages_zero_based and len(selected_pages_zero_based) < total_pages:
+        tag += f", page={format_spec(selected_pages_zero_based)}"
+    if crop:
+        tag += ", crop=true"
+    tag += "]]"
+    return tag

--- a/src/report_compiler/gui/pdf_render.py
+++ b/src/report_compiler/gui/pdf_render.py
@@ -1,0 +1,47 @@
+"""Raster rendering of PDF pages for GUI previews (PyMuPDF).
+
+Shared by all GUI features. ``render_page_png`` is pure PyMuPDF (testable without Qt);
+``render_page_pixmap`` wraps it into a QPixmap and is cached for the thumbnail grid.
+"""
+
+from __future__ import annotations
+
+import fitz  # PyMuPDF
+
+
+def page_count(pdf_path: str) -> int:
+    with fitz.open(pdf_path) as doc:
+        return len(doc)
+
+
+def render_page_png(pdf_path: str, page_index: int, target_width_px: int) -> bytes:
+    """Render one page to PNG bytes, scaled so its width is ~``target_width_px``."""
+    with fitz.open(pdf_path) as doc:
+        page = doc[page_index]
+        zoom = target_width_px / page.rect.width if page.rect.width else 1.0
+        pix = page.get_pixmap(matrix=fitz.Matrix(zoom, zoom), alpha=False)
+        return pix.tobytes("png")
+
+
+_pixmap_cache: dict = {}
+
+
+def render_page_pixmap(pdf_path: str, page_index: int, target_width_px: int):
+    """Render a page to a cached QPixmap. Imported lazily so this module stays
+    importable (for the PNG path) without PySide6 installed."""
+    from PySide6.QtGui import QPixmap
+
+    key = (pdf_path, page_index, target_width_px)
+    cached = _pixmap_cache.get(key)
+    if cached is not None:
+        return cached
+
+    png = render_page_png(pdf_path, page_index, target_width_px)
+    pixmap = QPixmap()
+    pixmap.loadFromData(png, "PNG")
+    _pixmap_cache[key] = pixmap
+    return pixmap
+
+
+def clear_cache() -> None:
+    _pixmap_cache.clear()

--- a/src/report_compiler/gui/pdf_render.py
+++ b/src/report_compiler/gui/pdf_render.py
@@ -1,34 +1,19 @@
-"""Raster rendering of PDF pages for GUI previews (PyMuPDF).
+"""GUI-side PDF rendering: re-exports the pure renderer and adds a cached QPixmap wrapper.
 
-Shared by all GUI features. ``render_page_png`` is pure PyMuPDF (testable without Qt);
-``render_page_pixmap`` wraps it into a QPixmap and is cached for the thumbnail grid.
+The pure functions live in ``report_compiler.utils.pdf_render`` so non-GUI code (the
+in-document overlay preview) can render without importing PySide6.
 """
 
 from __future__ import annotations
 
-import fitz  # PyMuPDF
-
-
-def page_count(pdf_path: str) -> int:
-    with fitz.open(pdf_path) as doc:
-        return len(doc)
-
-
-def render_page_png(pdf_path: str, page_index: int, target_width_px: int) -> bytes:
-    """Render one page to PNG bytes, scaled so its width is ~``target_width_px``."""
-    with fitz.open(pdf_path) as doc:
-        page = doc[page_index]
-        zoom = target_width_px / page.rect.width if page.rect.width else 1.0
-        pix = page.get_pixmap(matrix=fitz.Matrix(zoom, zoom), alpha=False)
-        return pix.tobytes("png")
-
+from report_compiler.utils.pdf_render import page_count, render_page_png  # noqa: F401 (re-export)
 
 _pixmap_cache: dict = {}
 
 
 def render_page_pixmap(pdf_path: str, page_index: int, target_width_px: int):
-    """Render a page to a cached QPixmap. Imported lazily so this module stays
-    importable (for the PNG path) without PySide6 installed."""
+    """Render a page to a cached QPixmap. PySide6 is imported lazily so this module
+    stays importable (for the re-exported PNG path) without PySide6 installed."""
     from PySide6.QtGui import QPixmap
 
     key = (pdf_path, page_index, target_width_px)

--- a/src/report_compiler/gui/word_writer.py
+++ b/src/report_compiler/gui/word_writer.py
@@ -1,0 +1,51 @@
+"""Write back to the live Word document via COM (used by the GUI dialogs).
+
+The dialog runs in its own process; it attaches to the already-running Word instance
+with ``GetActiveObject`` and inserts at a bookmark that the VBA launcher dropped at the
+user's selection. This mirrors the table insertion the VBA used to do directly.
+"""
+
+from __future__ import annotations
+
+import os
+
+try:
+    import win32com.client
+except ImportError:  # pragma: no cover - non-Windows
+    win32com = None
+
+
+def _find_document(word, doc_path: str):
+    """Return the open Document matching doc_path, else the active document."""
+    target = os.path.normcase(os.path.abspath(doc_path))
+    for doc in word.Documents:
+        try:
+            if os.path.normcase(os.path.abspath(doc.FullName)) == target:
+                return doc
+        except Exception:
+            continue
+    return word.ActiveDocument
+
+
+def insert_overlay_table(doc_path: str, anchor_bookmark: str, tag_text: str) -> None:
+    """Insert a 1x1 borderless table containing ``tag_text`` at the anchor bookmark.
+
+    Raises on failure so the caller can surface a message.
+    """
+    if win32com is None:
+        raise RuntimeError("pywin32 is not installed; cannot reach Word.")
+
+    word = win32com.client.GetActiveObject("Word.Application")
+    doc = _find_document(word, doc_path)
+
+    if anchor_bookmark and doc.Bookmarks.Exists(anchor_bookmark):
+        rng = doc.Bookmarks(anchor_bookmark).Range
+    else:
+        rng = word.Selection.Range
+
+    table = doc.Tables.Add(rng, 1, 1)
+    table.Borders.Enable = False
+    table.Cell(1, 1).Range.Text = tag_text
+
+    if anchor_bookmark and doc.Bookmarks.Exists(anchor_bookmark):
+        doc.Bookmarks(anchor_bookmark).Delete

--- a/src/report_compiler/pdf/overlay_processor.py
+++ b/src/report_compiler/pdf/overlay_processor.py
@@ -4,6 +4,7 @@ PDF overlay processing for table-based insertions.
 
 import fitz  # PyMuPDF
 from typing import Dict, List, Any
+from ..core.config import Config
 from ..utils.conversions import points_to_inches
 from ..utils.page_selector import PageSelector
 from ..utils.logging_config import get_overlay_logger
@@ -101,7 +102,7 @@ class OverlayProcessor:
             placeholder = data['placeholder']
             # Use the resolved absolute path, which is guaranteed by the compiler.
             pdf_path = placeholder['resolved_path']
-            crop_enabled = placeholder.get('crop_enabled', True)
+            crop_enabled = placeholder.get('crop_enabled', Config.DEFAULT_CROP_ENABLED)
             # Log the original path for user-facing messages.
             self.logger.info("  Processing overlay %d: %s", idx, placeholder['file_path'])
 

--- a/src/report_compiler/utils/page_selector.py
+++ b/src/report_compiler/utils/page_selector.py
@@ -31,28 +31,33 @@ class PageSelector:
                 'open_range_start': None,
                 'total_specified': 0
             }
-        
+
         pages = []
         open_range_start = None
-        
-        # Find all matches in the specification
-        matches = self.page_spec_regex.findall(page_spec.strip())
-        
-        for match in matches:
-            start_str, end_str = match
-            start = int(start_str)
-            
-            # Check if this is truly an open range (has a dash) vs just a single page
-            if end_str == '' and '-' in page_spec:  # Open range (e.g., "9-")
-                open_range_start = start - 1  # Convert to 0-based
-                break
-            elif end_str:  # Closed range (e.g., "1-3")
-                end = int(end_str)
-                for page_num in range(start, end + 1):
-                    pages.append(page_num - 1)  # Convert to 0-based
-            else:  # Single page (e.g., "7")
-                pages.append(start - 1)  # Convert to 0-based
-        
+
+        # Parse each comma-separated token independently. Whether a token is an open
+        # range ("9-") must be decided from the token itself, not from whether the whole
+        # spec contains a dash — otherwise "1-3,5" wrongly reads "5" as open-ended.
+        for token in page_spec.split(','):
+            token = token.strip()
+            if not token:
+                continue
+            try:
+                if '-' in token:  # Range: "1-3" (closed) or "9-" (open)
+                    start_str, end_str = token.split('-', 1)
+                    start = int(start_str.strip())
+                    end_str = end_str.strip()
+                    if end_str == '':
+                        open_range_start = start - 1  # Convert to 0-based
+                    else:
+                        end = int(end_str)
+                        for page_num in range(start, end + 1):
+                            pages.append(page_num - 1)  # Convert to 0-based
+                else:  # Single page: "7"
+                    pages.append(int(token) - 1)  # Convert to 0-based
+            except ValueError:
+                continue  # Skip malformed tokens
+
         return {
             'pages': sorted(list(set(pages))),  # Remove duplicates and sort
             'use_all': False,

--- a/src/report_compiler/utils/pdf_render.py
+++ b/src/report_compiler/utils/pdf_render.py
@@ -1,0 +1,38 @@
+"""Pure PyMuPDF raster rendering of PDF pages (no GUI dependency).
+
+Used by both the GUI thumbnail grid and the in-document overlay preview. Returning PNG
+bytes keeps this importable without PySide6; the QPixmap wrapper lives in
+``report_compiler.gui.pdf_render``.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import fitz  # PyMuPDF
+
+
+def page_count(pdf_path: str) -> int:
+    with fitz.open(pdf_path) as doc:
+        return len(doc)
+
+
+def render_page_png(
+    pdf_path: str,
+    page_index: int,
+    target_width_px: int,
+    clip: Optional[Tuple[float, float, float, float]] = None,
+) -> bytes:
+    """Render one page to PNG bytes, scaled so the rendered width is ~``target_width_px``.
+
+    ``clip`` is an optional (x0, y0, x1, y1) rectangle in PDF points; when given, only
+    that region is rendered (used for crop-accurate previews). The zoom is derived from
+    the clipped width so the output still lands near ``target_width_px``.
+    """
+    with fitz.open(pdf_path) as doc:
+        page = doc[page_index]
+        clip_rect = fitz.Rect(clip) if clip is not None else None
+        width_pts = clip_rect.width if clip_rect is not None else page.rect.width
+        zoom = target_width_px / width_pts if width_pts else 1.0
+        pix = page.get_pixmap(matrix=fitz.Matrix(zoom, zoom), clip=clip_rect, alpha=False)
+        return pix.tobytes("png")

--- a/word_integration/ReportingTools.bas
+++ b/word_integration/ReportingTools.bas
@@ -62,61 +62,46 @@ Public Sub InsertAppendixPlaceholder(control As IRibbonControl)
 End Sub
 
 Public Sub InsertOverlayPlaceholder(control As IRibbonControl)
-    ' Inserts a table-based placeholder for overlaying a PDF page.
-    
-    Dim pdfPath As String
+    ' Launches the PDF Overlay dialog via the COM server. The dialog (Python/PySide6)
+    ' shows page previews, lets the user pick a page range, then inserts the
+    ' [[OVERLAY: ...]] placeholder back into this document at the bookmark below.
+
+    Dim doc As Document
     Dim localDocPath As String
-    Dim localPdfPath As String
-    Dim relativePdfPath As String
-    Dim pageRange As String
-    Dim cropText As String
-    Dim placeholderText As String
-    Dim tbl As Table
-    Dim cc As ContentControl
-    
+    Dim anchorName As String
+    Dim compiler As Object
+
+    Set doc = ActiveDocument
+
     ' Ensure the document is saved before creating a relative path.
-    If ActiveDocument.Path = "" Then
+    If doc.Path = "" Then
         MsgBox "Please save the document first to create a relative path for the overlay.", vbExclamation, "Save Document"
         Exit Sub
     End If
 
-    ' Get the path to the PDF file from the user.
-    pdfPath = GetPdfPath()
-    If pdfPath = "" Then Exit Sub ' User cancelled
-    
-    ' Convert OneDrive/SharePoint paths to local paths for both document and selected PDF
-    localDocPath = GetLocalPath(ActiveDocument.Path, , True)
-    localPdfPath = GetLocalPath(pdfPath, , True)
-    
-    ' Calculate relative path using LibFileTools
-    relativePdfPath = GetRelativePath(localPdfPath, localDocPath)
-    
-    ' Prompt for optional parameters.
-    pageRange = InputBox("Enter an optional page range (e.g., 1-3,5). Leave blank for all pages.", "Overlay Page Selection")
-    
-    If MsgBox("Auto-crop the overlay to its content (removes whitespace)?", vbYesNo + vbQuestion, "Overlay Cropping") = vbNo Then
-        cropText = ", crop=false"
-    End If
-    
-    ' Construct the placeholder string.
-    placeholderText = "[[OVERLAY: " & relativePdfPath
-    If pageRange <> "" Then
-        placeholderText = placeholderText & ", page=" & pageRange
-    End If
-    placeholderText = placeholderText & cropText & "]]"
-    
-    ' Insert a 1x1 table at the current selection.
-    Set tbl = ActiveDocument.Tables.Add(Range:=Selection.Range, NumRows:=1, NumColumns:=1)
-    
-    ' Style the table to make it visible as a placeholder.
-    With tbl.Borders
-        .Enable = False
+    ' Resolve OneDrive/SharePoint path to a local path (kept in LibFileTools).
+    localDocPath = GetLocalPath(doc.FullName, , True)
 
-    End With
-    
-    ' Insert the placeholder text into the cell as plain text (no content control).
-    tbl.Cell(1, 1).Range.Text = placeholderText
-    
+    ' Drop a bookmark at the current selection so the dialog knows where to insert.
+    anchorName = "RC_OverlayAnchor"
+    On Error Resume Next
+    doc.Bookmarks(anchorName).Delete
+    On Error GoTo 0
+    doc.Bookmarks.Add Name:=anchorName, Range:=Selection.Range
+
+    ' Launch the dialog (returns immediately; Word stays responsive).
+    On Error GoTo ComError
+    Set compiler = CreateObject("ReportCompiler.Application")
+    compiler.LaunchOverlayDialog localDocPath, anchorName
+    Set compiler = Nothing
+    Exit Sub
+
+ComError:
+    MsgBox "Could not reach the Report Compiler COM server." & vbCrLf & vbCrLf & _
+           "Register it first by running:" & vbCrLf & _
+           "    uvx report-compiler com-server register", _
+           vbCritical, "COM Server Not Registered"
+    Set compiler = Nothing
 End Sub
 
 Public Sub InsertImagePlaceholder(control As IRibbonControl)

--- a/word_integration/ReportingTools.bas
+++ b/word_integration/ReportingTools.bas
@@ -426,6 +426,33 @@ Private Function GetImagePath() As String
 End Function
 
 
+Public Sub LaunchLinkManagerUI(control As IRibbonControl)
+    ' Opens the Link Manager window via the COM server.
+    Dim doc As Document
+    Dim localDocPath As String
+    Dim compiler As Object
+
+    Set doc = ActiveDocument
+    If doc.Path = "" Then
+        MsgBox "Please save the document first.", vbExclamation, "Save Document"
+        Exit Sub
+    End If
+    localDocPath = GetLocalPath(doc.FullName, , True)
+
+    On Error GoTo ComError
+    Set compiler = CreateObject("ReportCompiler.Application")
+    compiler.LaunchLinkManager localDocPath
+    Set compiler = Nothing
+    Exit Sub
+
+ComError:
+    MsgBox "Could not reach the Report Compiler COM server." & vbCrLf & vbCrLf & _
+           "Register it first by running:" & vbCrLf & _
+           "    uvx report-compiler com-server register", _
+           vbCritical, "COM Server Not Registered"
+    Set compiler = Nothing
+End Sub
+
 Public Sub OnOverlayViewChange(control As IRibbonControl, id As String, index As Integer)
     ' Ribbon "Overlay view" dropdown: 0 = Tags, 1 = Quick preview, 2 = Full preview.
     Dim mode As String

--- a/word_integration/ReportingTools.bas
+++ b/word_integration/ReportingTools.bas
@@ -422,7 +422,54 @@ Private Function GetImagePath() As String
             GetImagePath = "" ' User cancelled
         End If
     End With
-    
+
 End Function
+
+
+Public Sub OnOverlayViewChange(control As IRibbonControl, id As String, index As Integer)
+    ' Ribbon "Overlay view" dropdown: 0 = Tags, 1 = Quick preview, 2 = Full preview.
+    Dim mode As String
+    Select Case index
+        Case 1
+            mode = "quick"
+        Case 2
+            mode = "full"
+        Case Else
+            mode = "tags"
+    End Select
+    ApplyOverlayView mode
+End Sub
+
+Public Sub RepairOverlays(control As IRibbonControl)
+    ' Force every overlay back to its canonical tag form (recovery).
+    ApplyOverlayView "tags"
+End Sub
+
+Private Sub ApplyOverlayView(mode As String)
+    ' Drives the COM server to switch the whole document's overlay view.
+    Dim doc As Document
+    Dim localDocPath As String
+    Dim compiler As Object
+
+    Set doc = ActiveDocument
+    If doc.Path = "" Then
+        MsgBox "Please save the document first.", vbExclamation, "Save Document"
+        Exit Sub
+    End If
+    localDocPath = GetLocalPath(doc.FullName, , True)
+
+    On Error GoTo ComError
+    Set compiler = CreateObject("ReportCompiler.Application")
+    compiler.SetOverlayPreview localDocPath, mode
+    Set compiler = Nothing
+    Exit Sub
+
+ComError:
+    MsgBox "Could not reach the Report Compiler COM server." & vbCrLf & vbCrLf & _
+           "Register it first by running:" & vbCrLf & _
+           "    uvx report-compiler com-server register", _
+           vbCritical, "COM Server Not Registered"
+    Set compiler = Nothing
+End Sub
 
 

--- a/word_integration/report_compiler_UI.xml
+++ b/word_integration/report_compiler_UI.xml
@@ -52,6 +52,16 @@
                   supertip="Force all overlays back to their tag form (recovery)."/>
         </group>
 
+        <group id="groupLinks" label="Links">
+          <button id="btnLinkManager"
+                  label="Link manager"
+                  size="large"
+                  onAction="LaunchLinkManagerUI"
+                  imageMso="HyperlinkInsert"
+                  screentip="Link manager"
+                  supertip="List every link in the document, check validity, and fix or relink paths."/>
+        </group>
+
         <group id="groupCompiler" label="Compiler">
           <button id="btnCompileReport"
                   label="Compile Report"

--- a/word_integration/report_compiler_UI.xml
+++ b/word_integration/report_compiler_UI.xml
@@ -34,6 +34,24 @@
                   supertip="Converts a single PDF page to high-quality SVG and inserts it as an image."/>
         </group>
         
+        <group id="groupOverlayPreview" label="Overlay Preview">
+          <dropDown id="ddOverlayView"
+                  label="View"
+                  onAction="OnOverlayViewChange"
+                  screentip="Overlay view"
+                  supertip="Switch all overlays between tags, quick preview, and full preview.">
+            <item id="ovTags" label="Tags"/>
+            <item id="ovQuick" label="Quick preview"/>
+            <item id="ovFull" label="Full preview"/>
+          </dropDown>
+          <button id="btnRepairOverlays"
+                  label="Repair overlays"
+                  onAction="RepairOverlays"
+                  imageMso="Refresh"
+                  screentip="Repair overlays"
+                  supertip="Force all overlays back to their tag form (recovery)."/>
+        </group>
+
         <group id="groupCompiler" label="Compiler">
           <button id="btnCompileReport"
                   label="Compile Report"


### PR DESCRIPTION
## Why this PR exists

The stacked GUI PRs (#14 overlay dialog, #13 in-document preview, #15 link manager) were merged **onto each other**, not onto `main` — only #12 (the COM server) ever reached `main`. Meanwhile `main` advanced independently with the single-pass pipeline (#10) and caching (#11). So the GUI features were stranded and `main` had diverged.

This branch merges the full feature stack (`feat/word-link-manager`, which contains everything) into `main` and reconciles the two lines of work, then rewrites the README.

## Merge reconciliation

The merge touched five files changed on both sides; all resolved coherently and verified:

- **`compiler.py`** — `main`'s single-pass `_find_placeholders` rewrite + the preview feature's `normalize_overlay_previews` hook now coexist: normalization runs first (collapsing any saved-in-preview overlays), then the single parse caches the document that the single-pass modify step reuses.
- **`config.py`** — keeps `main`'s caching constants **and** the overlay-preview marker; `DEFAULT_CROP_ENABLED` resolves to `False` (the intended default).
- **`docx_processor.py`** — `main`'s pre-parsed-document reuse + the preview normalizer methods.
- **`overlay_processor.py`** — `main`'s single-pass edits + the crop default sourced from `Config`.
- **`pyproject.toml`** — adds `PySide6` alongside existing deps.

## What lands on main

The complete Word integration: COM server (Compile / Insert PDF Page), the **Insert Overlay dialog**, the **in-document overlay preview** (Tags/Quick/Full), and the **Link manager**, plus the COM registration and source-based `.dotm` build.

## README

Rewritten for non-technical end-users: leads with the Word/ribbon workflow, a one-time setup section, and a plain-language troubleshooting table; CLI and placeholder-tag reference moved to a power-user section. Screenshots are referenced from `docs/images/` (to be added — see checklist below).

## Verification

Headless tests pass on the merged tree: overlay logic, link-index classify/rewrite, and the compile-time overlay normalizer round-trip (expanded preview → canonical 1×1 → parser finds it). Full import surface + all 7 COM methods present. (Live COM/Word paths verified previously on a real session; not runnable in CI.)

## Follow-up

Screenshots to drop into `docs/images/`: `ribbon.png`, `overlay-dialog.png`, `overlay-preview.png`, `link-manager.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)